### PR TITLE
Remove last DadguideItem classes, including DadguideItem itself

### DIFF
--- a/dadguide/database_context.py
+++ b/dadguide/database_context.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from collections import OrderedDict, defaultdict, deque
+from typing import Optional
 
 from .database_manager import DadguideDatabase
 from .monster_graph import MonsterGraph
@@ -80,7 +81,7 @@ class DbContext(object):
             DgScheduledEvent,
             as_generator=as_generator)
 
-    def get_dungeon_by_id(self, dungeon_id: int):
+    def get_dungeon_by_id(self, dungeon_id: int) -> Optional[DungeonModel]:
         dungeon = self.database.query_one(
             DUNGEON_QUERY.format(dungeon_id=dungeon_id), (), DictWithAttrAccess)
         dungeon_model = DungeonModel(**dungeon) if dungeon else None

--- a/dadguide/database_context.py
+++ b/dadguide/database_context.py
@@ -4,9 +4,18 @@ from collections import OrderedDict, defaultdict, deque
 from .database_manager import DadguideDatabase
 from .monster_graph import MonsterGraph
 from .database_manager import DadguideItem
-from .database_manager import DgDungeon
 from .database_manager import DictWithAttrAccess
 from .database_manager import DgScheduledEvent
+from .models.dungeon_model import DungeonModel
+
+
+DUNGEON_QUERY = """SELECT
+  dungeons.*
+FROM
+  dungeons
+WHERE
+  dungeons.dungeon_id = "{dungeon_id}" """
+
 
 
 class DbContext(object):
@@ -72,7 +81,10 @@ class DbContext(object):
             as_generator=as_generator)
 
     def get_dungeon_by_id(self, dungeon_id: int):
-        return self.database.select_one_entry_by_pk(dungeon_id, DgDungeon)
+        dungeon = self.database.query_one(
+            DUNGEON_QUERY.format(dungeon_id=dungeon_id), (), DictWithAttrAccess)
+        dungeon_model = DungeonModel(**dungeon) if dungeon else None
+        return dungeon_model
 
     def get_base_monster_ids(self):
         SELECT_BASE_MONSTER_ID = '''

--- a/dadguide/database_context.py
+++ b/dadguide/database_context.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from .database_manager import DadguideDatabase
 from .monster_graph import MonsterGraph
-from .database_manager import DictWithAttrAccess
 from .models.scheduled_event_model import ScheduledEventModel
 from .models.dungeon_model import DungeonModel
 
@@ -28,7 +27,7 @@ class DbContext(object):
         SELECT_AWOKEN_SKILL_IDS = 'SELECT awoken_skill_id from awoken_skills'
         return [r.awoken_skill_id for r in
                 self.database.query_many(
-                    SELECT_AWOKEN_SKILL_IDS, (), DictWithAttrAccess, as_generator=True)]
+                    SELECT_AWOKEN_SKILL_IDS, (), as_generator=True)]
 
     def get_next_evolutions_by_monster(self, monster_id):
         return self.graph.get_next_evolutions_by_monster_id(monster_id)
@@ -63,7 +62,6 @@ class DbContext(object):
     def get_all_monster_ids_query(self, as_generator=True):
         query = self.database.query_many(
             self.database.select_builder(tables={'monsters': ('monster_id',)}), (),
-            DictWithAttrAccess,
             as_generator=as_generator)
         if as_generator:
             return map(lambda m: m.monster_id, query)
@@ -76,7 +74,7 @@ class DbContext(object):
         return monsters
 
     def get_all_events(self) -> ScheduledEventModel:
-        result = self.database.query_many(SCHEDULED_EVENT_QUERY, (), DictWithAttrAccess)
+        result = self.database.query_many(SCHEDULED_EVENT_QUERY, ())
         for se in result:
             se['dungeon_model'] = DungeonModel(name_ja=se['d_name_ja'],
                                                name_en=se['d_name_en'],
@@ -92,7 +90,6 @@ class DbContext(object):
         return self.database.query_many(
             SELECT_BASE_MONSTER_ID,
             (),
-            DictWithAttrAccess,
             as_generator=True)
 
     def has_database(self):

--- a/dadguide/database_context.py
+++ b/dadguide/database_context.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from .database_manager import DadguideDatabase
 from .monster_graph import MonsterGraph
-from .database_manager import DadguideItem
 from .database_manager import DictWithAttrAccess
 from .models.scheduled_event_model import ScheduledEventModel
 from .models.dungeon_model import DungeonModel
@@ -29,7 +28,7 @@ class DbContext(object):
         SELECT_AWOKEN_SKILL_IDS = 'SELECT awoken_skill_id from awoken_skills'
         return [r.awoken_skill_id for r in
                 self.database.query_many(
-                    SELECT_AWOKEN_SKILL_IDS, (), DadguideItem, as_generator=True)]
+                    SELECT_AWOKEN_SKILL_IDS, (), DictWithAttrAccess, as_generator=True)]
 
     def get_next_evolutions_by_monster(self, monster_id):
         return self.graph.get_next_evolutions_by_monster_id(monster_id)

--- a/dadguide/database_context.py
+++ b/dadguide/database_context.py
@@ -20,14 +20,6 @@ FROM
   schedule LEFT OUTER JOIN dungeons ON schedule.dungeon_id = dungeons.dungeon_id"""
 
 
-DUNGEON_QUERY = """SELECT
-  dungeons.*
-FROM
-  dungeons
-WHERE
-  dungeons.dungeon_id = "{dungeon_id}" """
-
-
 class DbContext(object):
     def __init__(self, database: DadguideDatabase, graph: MonsterGraph):
         self.database = database
@@ -92,12 +84,6 @@ class DbContext(object):
                                                name_ko=se['d_name_ko'],
                                                **se)
             yield ScheduledEventModel(**se)
-
-    def get_dungeon_by_id(self, dungeon_id: int) -> Optional[DungeonModel]:
-        dungeon = self.database.query_one(
-            DUNGEON_QUERY.format(dungeon_id=dungeon_id), (), DictWithAttrAccess)
-        dungeon_model = DungeonModel(**dungeon) if dungeon else None
-        return dungeon_model
 
     def get_base_monster_ids(self):
         SELECT_BASE_MONSTER_ID = '''

--- a/dadguide/database_manager.py
+++ b/dadguide/database_manager.py
@@ -160,30 +160,6 @@ class DadguideItem(DictWithAttrAccess):
         return self[self.PK]
 
 
-class DgScheduledEvent(DadguideItem):
-    TABLE = 'schedule'
-    PK = 'event_id'
-
-    def __init__(self, item):
-        super(DgScheduledEvent, self).__init__(item)
-
-    @property
-    def open_datetime(self):
-        return datetime.utcfromtimestamp(self.start_timestamp).replace(tzinfo=pytz.UTC)
-
-    @open_datetime.setter
-    def open_datetime(self, value):
-        self.start_timestamp = int(value.timestamp())
-
-    @property
-    def close_datetime(self):
-        return datetime.utcfromtimestamp(self.end_timestamp).replace(tzinfo=pytz.UTC)
-
-    @close_datetime.setter
-    def close_datetime(self, value):
-        self.end_timestamp = int(value.timestamp())
-
-
 class PotentialMatches(object):
     def __init__(self):
         self.match_list = set()

--- a/dadguide/database_manager.py
+++ b/dadguide/database_manager.py
@@ -160,11 +160,6 @@ class DadguideItem(DictWithAttrAccess):
         return self[self.PK]
 
 
-class DgDungeon(DadguideItem):
-    TABLE = 'dungeons'
-    PK = 'dungeon_id'
-
-
 class DgScheduledEvent(DadguideItem):
     TABLE = 'schedule'
     PK = 'event_id'

--- a/dadguide/database_manager.py
+++ b/dadguide/database_manager.py
@@ -75,19 +75,13 @@ class DadguideDatabase(object):
         cursor.execute(query, param)
         res = cursor.fetchone()
         if res is not None:
-            if issubclass(d_type, DadguideItem):
-                return d_type(res)
-            else:
-                return d_type(res)
+            return d_type(res)
         return None
 
     def as_generator(self, cursor, d_type):
         res = cursor.fetchone()
         while res is not None:
-            if issubclass(d_type, DadguideItem):
-                yield d_type(res)
-            else:
-                yield d_type(res)
+            yield d_type(res)
             res = cursor.fetchone()
 
     def query_many(self, query, param, d_type, idx_key=None, as_generator=False):
@@ -97,21 +91,12 @@ class DadguideDatabase(object):
             return []
         if as_generator:
             return (d_type(res)
-                    if issubclass(d_type, DadguideItem)
-                    else d_type(res)
                     for res in cursor.fetchall())
         else:
             if idx_key is None:
-                if issubclass(d_type, DadguideItem):
-                    return [d_type(res) for res in cursor.fetchall()]
-                else:
-                    return [d_type(res) for res in cursor.fetchall()]
+                return [d_type(res) for res in cursor.fetchall()]
             else:
-                if issubclass(d_type, DadguideItem):
-                    return DictWithAttrAccess(
-                        {res[idx_key]: d_type(res) for res in cursor.fetchall()})
-                else:
-                    return DictWithAttrAccess({res[idx_key]: d_type(res) for res in cursor.fetchall()})
+                return DictWithAttrAccess({res[idx_key]: d_type(res) for res in cursor.fetchall()})
 
     def select_one_entry_by_pk(self, pk, d_type):
         return self.query_one(
@@ -139,25 +124,6 @@ class DictWithAttrAccess(dict):
     def __init__(self, item):
         super(DictWithAttrAccess, self).__init__(item)
         self.__dict__ = self
-
-
-class DadguideItem(DictWithAttrAccess):
-    """
-    Base class for all items loaded from DadGuide.
-    Is a dict with attr access.
-    """
-    TABLE = None
-    FIELDS = '*'
-    PK = None
-    AS_BOOL = ()
-
-    def __init__(self, item):
-        super(DadguideItem, self).__init__(item)
-        for k in self.AS_BOOL:
-            self[k] = bool(self[k])
-
-    def key(self):
-        return self[self.PK]
 
 
 class PotentialMatches(object):

--- a/dadguide/models/dungeon_model.py
+++ b/dadguide/models/dungeon_model.py
@@ -6,9 +6,44 @@ class DungeonModel(BaseModel):
         self.dungeon_id = kwargs['dungeon_id']
         self.name_ja = kwargs['name_ja']
         self.name_en = kwargs['name_en']
+        self.clean_name_en = self._make_clean_name_en(self.name_en)
         self.name_ko = kwargs['name_ko']
 
         self.dungeon_type = kwargs['dungeon_type']
+
+    @staticmethod
+    def _make_clean_name_en(name):
+        if 'tamadra invades in some tech' in name.lower():
+            return 'Latents invades some Techs & 20x +Eggs'
+        if '1.5x Bonus Pal Point in multiplay' in name:
+            name = '[Descends] 1.5x Pal Points in multiplay'
+        name = name.replace('No Continues', 'No Cont')
+        name = name.replace('No Continue', 'No Cont')
+        name = name.replace('Some Limited Time Dungeons', 'Some Guerrillas')
+        name = name.replace('are added in', 'in')
+        name = name.replace('!', '')
+        name = name.replace('Dragon Infestation', 'Dragons')
+        name = name.replace(' Infestation', 's')
+        name = name.replace('Daily Descended Dungeon', 'Daily Descends')
+        name = name.replace('Chance for ', '')
+        name = name.replace('Jewel of the Spirit', 'Spirit Jewel')
+        name = name.replace(' & ', '/')
+        name = name.replace(' / ', '/')
+        name = name.replace('PAD Radar', 'PADR')
+        name = name.replace('in normal dungeons', 'in normals')
+        name = name.replace('Selected ', 'Some ')
+        name = name.replace('Enhanced ', 'Enh ')
+        name = name.replace('All Att. Req.', 'All Att.')
+        name = name.replace('Extreme King Metal Dragon', 'Extreme KMD')
+        name = name.replace('Golden Mound-Tricolor [Fr/Wt/Wd Only]', 'Golden Mound')
+        name = name.replace('Gods-Awakening Materials Descended', "Awoken Mats")
+        name = name.replace('Orb move time 4 sec', '4s move time')
+        name = name.replace('Awakening Materials Descended', 'Awkn Mats')
+        name = name.replace('Awakening Materials', 'Awkn Mats')
+        name = name.replace("Star Treasure Thieves' Den", 'STTD')
+        name = name.replace('Ruins of the Star Vault', 'Star Vault')
+        name = name.replace('-★6 or lower Enhanced', '')
+        return name
 
     def to_dict(self):
         return {

--- a/dadguide/models/dungeon_model.py
+++ b/dadguide/models/dungeon_model.py
@@ -1,0 +1,18 @@
+from .base_model import BaseModel
+
+
+class DungeonModel(BaseModel):
+    def __init__(self, **kwargs):
+        self.dungeon_id = kwargs['dungeon_id']
+        self.name_ja = kwargs['name_ja']
+        self.name_en = kwargs['name_en']
+        self.name_ko = kwargs['name_ko']
+
+        self.dungeon_type = kwargs['dungeon_type']
+
+    def to_dict(self):
+        return {
+            'dungeon_id': self.dungeon_id,
+            'name_ja': self.name_ja,
+            'name_en': self.name_en
+        }

--- a/dadguide/models/dungeon_model.py
+++ b/dadguide/models/dungeon_model.py
@@ -17,32 +17,36 @@ class DungeonModel(BaseModel):
             return 'Latents invades some Techs & 20x +Eggs'
         if '1.5x Bonus Pal Point in multiplay' in name:
             name = '[Descends] 1.5x Pal Points in multiplay'
-        name = name.replace('No Continues', 'No Cont')
-        name = name.replace('No Continue', 'No Cont')
-        name = name.replace('Some Limited Time Dungeons', 'Some Guerrillas')
-        name = name.replace('are added in', 'in')
-        name = name.replace('!', '')
-        name = name.replace('Dragon Infestation', 'Dragons')
-        name = name.replace(' Infestation', 's')
-        name = name.replace('Daily Descended Dungeon', 'Daily Descends')
-        name = name.replace('Chance for ', '')
-        name = name.replace('Jewel of the Spirit', 'Spirit Jewel')
-        name = name.replace(' & ', '/')
-        name = name.replace(' / ', '/')
-        name = name.replace('PAD Radar', 'PADR')
-        name = name.replace('in normal dungeons', 'in normals')
-        name = name.replace('Selected ', 'Some ')
-        name = name.replace('Enhanced ', 'Enh ')
-        name = name.replace('All Att. Req.', 'All Att.')
-        name = name.replace('Extreme King Metal Dragon', 'Extreme KMD')
-        name = name.replace('Golden Mound-Tricolor [Fr/Wt/Wd Only]', 'Golden Mound')
-        name = name.replace('Gods-Awakening Materials Descended', "Awoken Mats")
-        name = name.replace('Orb move time 4 sec', '4s move time')
-        name = name.replace('Awakening Materials Descended', 'Awkn Mats')
-        name = name.replace('Awakening Materials', 'Awkn Mats')
-        name = name.replace("Star Treasure Thieves' Den", 'STTD')
-        name = name.replace('Ruins of the Star Vault', 'Star Vault')
-        name = name.replace('-★6 or lower Enhanced', '')
+        clean_name_map = {
+            'No Continues': 'No Cont',
+            'No Continue': 'No Cont',
+            'Some Limited Time Dungeons': 'Some Guerrillas',
+            'are added in': 'in',
+            '!': '',
+            'Dragon Infestation': 'Dragons',
+            ' Infestation': 's',
+            'Daily Descended Dungeon': 'Daily Descends',
+            'Chance for ': '',
+            'Jewel of the Spirit': 'Spirit Jewel',
+            ' & ': '/',
+            ' / ': '/',
+            'PAD Radar': 'PADR',
+            'in normal dungeons': 'in normals',
+            'Selected ': 'Some ',
+            'Enhanced ': 'Enh ',
+            'All Att. Req.': 'All Att.',
+            'Extreme King Metal Dragon': 'Extreme KMD',
+            'Golden Mound-Tricolor [Fr/Wt/Wd Only]': 'Golden Mound',
+            'Gods-Awakening Materials Descended': "Awoken Mats",
+            'Orb move time 4 sec': '4s move time',
+            'Awakening Materials Descended': 'Awkn Mats',
+            'Awakening Materials': 'Awkn Mats',
+            "Star Treasure Thieves' Den": 'STTD',
+            'Ruins of the Star Vault': 'Star Vault',
+            '-★6 or lower Enhanced': '',
+        }
+        for find, replace in clean_name_map.items():
+            name = name.replace(find, replace)
         return name
 
     def to_dict(self):

--- a/dadguide/models/scheduled_event_model.py
+++ b/dadguide/models/scheduled_event_model.py
@@ -1,0 +1,44 @@
+from .base_model import BaseModel
+from .dungeon_model import DungeonModel
+from datetime import datetime
+import pytz
+
+
+class ScheduledEventModel(BaseModel):
+    def __init__(self, **kwargs):
+        self.event_id = kwargs["event_id"]
+        self.server_id = kwargs["server_id"]
+        self.event_type_id = kwargs["event_type_id"]
+        self.start_timestamp = kwargs["start_timestamp"]
+        self.end_timestamp = kwargs["end_timestamp"]
+        self.group_name = kwargs["group_name"]
+
+        self.dungeon: DungeonModel = kwargs["dungeon_model"]
+        self.dungeon_id = self.dungeon.dungeon_id
+
+    def key(self):
+        """
+        This is just here for compatibility and will be deleted
+        """
+        return self.event_id
+
+    @property
+    def open_datetime(self):
+        return datetime.utcfromtimestamp(self.start_timestamp).replace(tzinfo=pytz.UTC)
+
+    @open_datetime.setter
+    def open_datetime(self, value):
+        self.start_timestamp = int(value.timestamp())
+
+    @property
+    def close_datetime(self):
+        return datetime.utcfromtimestamp(self.end_timestamp).replace(tzinfo=pytz.UTC)
+
+    @close_datetime.setter
+    def close_datetime(self, value):
+        self.end_timestamp = int(value.timestamp())
+
+    def to_dict(self):
+        return {
+            'dungeon_id': self.event_id,
+        }

--- a/dadguide/models/scheduled_event_model.py
+++ b/dadguide/models/scheduled_event_model.py
@@ -7,14 +7,14 @@ import pytz
 class ScheduledEventModel(BaseModel):
     def __init__(self, **kwargs):
         self.event_id = kwargs["event_id"]
-        self.server_id = kwargs["server_id"]
-        self.event_type_id = kwargs["event_type_id"]
-        self.start_timestamp = kwargs["start_timestamp"]
-        self.end_timestamp = kwargs["end_timestamp"]
-        self.group_name = kwargs["group_name"]
+        self.server_id = kwargs.get("server_id")
+        self.event_type_id = kwargs.get("event_type_id")
+        self.start_timestamp = kwargs.get("start_timestamp")
+        self.end_timestamp = kwargs.get("end_timestamp")
+        self.group_name = kwargs.get("group_name")
 
-        self.dungeon: DungeonModel = kwargs["dungeon_model"]
-        self.dungeon_id = self.dungeon.dungeon_id
+        self.dungeon: DungeonModel = kwargs.get("dungeon_model")
+        self.dungeon_id = self.dungeon.dungeon_id if self.dungeon else None
 
     def key(self):
         """

--- a/dadguide/models/scheduled_event_model.py
+++ b/dadguide/models/scheduled_event_model.py
@@ -16,12 +16,6 @@ class ScheduledEventModel(BaseModel):
         self.dungeon: DungeonModel = kwargs.get("dungeon_model")
         self.dungeon_id = self.dungeon.dungeon_id if self.dungeon else None
 
-    def key(self):
-        """
-        This is just here for compatibility and will be deleted
-        """
-        return self.event_id
-
     @property
     def open_datetime(self):
         return datetime.utcfromtimestamp(self.start_timestamp).replace(tzinfo=pytz.UTC)

--- a/dadguide/monster_graph.py
+++ b/dadguide/monster_graph.py
@@ -3,7 +3,6 @@ import json
 from typing import Optional
 from collections import defaultdict
 from .database_manager import DadguideDatabase
-from .database_manager import DictWithAttrAccess
 from .models.enum_types import EvoType, InternalEvoType
 from .models.monster_model import MonsterModel
 from .models.leader_skill_model import LeaderSkillModel
@@ -101,10 +100,10 @@ class MonsterGraph(object):
     def build_graph(self):
         self.graph = networkx.MultiDiGraph()
 
-        ms = self.database.query_many(MONSTER_QUERY, (), DictWithAttrAccess)
-        es = self.database.query_many(EVOS_QUERY, (), DictWithAttrAccess)
-        aws = self.database.query_many(AWAKENINGS_QUERY, (), DictWithAttrAccess)
-        ems = self.database.query_many(EGG_QUERY, (), DictWithAttrAccess)
+        ms = self.database.query_many(MONSTER_QUERY, ())
+        es = self.database.query_many(EVOS_QUERY, ())
+        aws = self.database.query_many(AWAKENINGS_QUERY, ())
+        ems = self.database.query_many(EGG_QUERY, ())
 
         mtoawo = defaultdict(list)
         for a in aws:

--- a/padevents/padevents.py
+++ b/padevents/padevents.py
@@ -924,7 +924,7 @@ class PadEventSettings(CogSettings):
 class Event:
     def __init__(self, scheduled_event: "ScheduledEventModel", db_context):
         self.db_context = db_context
-        self.key = scheduled_event.key()
+        self.key = scheduled_event.event_id
         self.server = SUPPORTED_SERVERS[scheduled_event.server_id]
         self.open_datetime = scheduled_event.open_datetime
         self.close_datetime = scheduled_event.close_datetime

--- a/padevents/padevents.py
+++ b/padevents/padevents.py
@@ -933,7 +933,7 @@ class Event:
         self.dungeon_name = self.dungeon.name_en if self.dungeon else 'unknown_dungeon'
         self.event_name = ''  # scheduled_event.event.name if scheduled_event.event else ''
 
-        self.clean_dungeon_name = cleanDungeonNames(self.dungeon_name)
+        self.clean_dungeon_name = self.dungeon.clean_name_en if self.dungeon else 'unknown_dungeon'
         self.clean_event_name = self.event_name.replace('!', '').replace(' ', '')
 
         self.name_and_modifier = self.clean_dungeon_name
@@ -1133,39 +1133,3 @@ def isEventWanted(event):
         return False
 
     return True
-
-
-def cleanDungeonNames(name):
-    # TODO: Make this info internally stored
-    if 'tamadra invades in some tech' in name.lower():
-        return 'Latents invades some Techs & 20x +Eggs'
-    if '1.5x Bonus Pal Point in multiplay' in name:
-        name = '[Descends] 1.5x Pal Points in multiplay'
-    name = name.replace('No Continues', 'No Cont')
-    name = name.replace('No Continue', 'No Cont')
-    name = name.replace('Some Limited Time Dungeons', 'Some Guerrillas')
-    name = name.replace('are added in', 'in')
-    name = name.replace('!', '')
-    name = name.replace('Dragon Infestation', 'Dragons')
-    name = name.replace(' Infestation', 's')
-    name = name.replace('Daily Descended Dungeon', 'Daily Descends')
-    name = name.replace('Chance for ', '')
-    name = name.replace('Jewel of the Spirit', 'Spirit Jewel')
-    name = name.replace(' & ', '/')
-    name = name.replace(' / ', '/')
-    name = name.replace('PAD Radar', 'PADR')
-    name = name.replace('in normal dungeons', 'in normals')
-    name = name.replace('Selected ', 'Some ')
-    name = name.replace('Enhanced ', 'Enh ')
-    name = name.replace('All Att. Req.', 'All Att.')
-    name = name.replace('Extreme King Metal Dragon', 'Extreme KMD')
-    name = name.replace('Golden Mound-Tricolor [Fr/Wt/Wd Only]', 'Golden Mound')
-    name = name.replace('Gods-Awakening Materials Descended', "Awoken Mats")
-    name = name.replace('Orb move time 4 sec', '4s move time')
-    name = name.replace('Awakening Materials Descended', 'Awkn Mats')
-    name = name.replace('Awakening Materials', 'Awkn Mats')
-    name = name.replace("Star Treasure Thieves' Den", 'STTD')
-    name = name.replace('Ruins of the Star Vault', 'Star Vault')
-    name = name.replace('-★6 or lower Enhanced', '')
-
-    return name

--- a/padevents/padevents.py
+++ b/padevents/padevents.py
@@ -16,6 +16,11 @@ from redbot.core import commands, Config
 from redbot.core.utils.chat_formatting import box, inline, pagify
 from tsutils import CogSettings, confirm_message
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from dadguide.database_context import DbContext
+    from dadguide.models.scheduled_event_model import ScheduledEventModel
+
 logger = logging.getLogger('red.padbot-cogs.padevents')
 
 SUPPORTED_SERVERS = ["JP", "NA", "KR"]
@@ -917,14 +922,14 @@ class PadEventSettings(CogSettings):
 
 
 class Event:
-    def __init__(self, scheduled_event: "DgScheduledEvent", db_context):
+    def __init__(self, scheduled_event: "ScheduledEventModel", db_context):
         self.db_context = db_context
         self.key = scheduled_event.key()
         self.server = SUPPORTED_SERVERS[scheduled_event.server_id]
         self.open_datetime = scheduled_event.open_datetime
         self.close_datetime = scheduled_event.close_datetime
         self.group = scheduled_event.group_name
-        self.dungeon = self.db_context.get_dungeon_by_id(scheduled_event.dungeon_id)
+        self.dungeon = scheduled_event.dungeon
         self.dungeon_name = self.dungeon.name_en if self.dungeon else 'unknown_dungeon'
         self.event_name = ''  # scheduled_event.event.name if scheduled_event.event else ''
 

--- a/padevents/padevents.py
+++ b/padevents/padevents.py
@@ -203,7 +203,7 @@ class PadEvents(commands.Cog):
         await dg_cog.wait_until_ready()
         dg_module = __import__(dg_cog.__module__)
 
-        te = dg_module.DgScheduledEvent({'dungeon_id': 1}, dg_cog.database)
+        te = dg_module.ScheduledEventModule({'dungeon_id': 1})
 
         te.server = server
         te.server_id = SUPPORTED_SERVERS.index(server)


### PR DESCRIPTION
My branch name lied cos there's still something using DadguideItem itself in pdchu I think

I may have broken testevent but testevent isn't even working on Tsubaki right now?? so idk?????? Also I got rid of the ability to query a single dungeon at a time because that seems completely unnecessary and replaced it with a join in the query for all events, so the `padevents` cog loads like 10x as fast now lol