### PR TITLE
Fix old index's handling of base transform monsters

### DIFF
--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from dadguide.database_context import DbContext
     from dadguide.models.monster_model import MonsterModel
+    from dadguide.old_monster_index import NamedMonster
 
 logger = logging.getLogger('red.padbot-cogs.padinfo')
 
@@ -845,7 +846,7 @@ class PadInfo(commands.Cog):
 
         return m, err, debug_info
 
-    async def _findMonster(self, query, server_filter=ServerFilter.any):
+    async def _findMonster(self, query, server_filter=ServerFilter.any) -> "NamedMonster":
         while self.index_lock.locked():
             await asyncio.sleep(1)
 


### PR DESCRIPTION
Fixes an issue with `^which` not working for transform monsters, which was reported specifically for Grandis. Also added type hinting in padinfo. A more robust fix would be to improve the query in DbContext but this is good enough and we're replacing this entire thing soon anyway.