### PR TITLE
Fix arlatent order

### DIFF
--- a/dadguide/models/enum_types.py
+++ b/dadguide/models/enum_types.py
@@ -54,9 +54,9 @@ class Server(Enum):
 
 class AwakeningRestrictedLatent(Enum):
     """Latent awakenings with availability gated by having an awakening"""
-    AbsorbPierce = 606
+    UnmatchableClear = 606
     SpinnerClear = 607
-    UnmatchableClear = 608
+    AbsorbPierce = 608
 
 
 def enum_or_none(enum, value, default=None):

--- a/dadguide/models/monster_model.py
+++ b/dadguide/models/monster_model.py
@@ -117,8 +117,8 @@ class MonsterModel(BaseModel):
     def awakening_restricted_latents(self):
         monster_awakening_to_allowed_latent_map = [
             {27: AwakeningRestrictedLatent.UnmatchableClear},  # TPA
-            {62: AwakeningRestrictedLatent.AbsorbPierce},  # Combo orb
             {20: AwakeningRestrictedLatent.SpinnerClear},  # Bind clear
+            {62: AwakeningRestrictedLatent.AbsorbPierce},  # Combo orb
         ]
         latents = []
         for row in monster_awakening_to_allowed_latent_map:

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -583,7 +583,7 @@ AWAKENING_ID_TO_EMOJI_NAME_MAP = {
 
 
 AWAKENING_RESTRICTED_LATENT_VALUE_TO_EMOJI_NAME_MAP = {
-    606: 'absorb_pierce',
+    606: 'unmatchable_clear',
     607: 'spinner_clear',
-    608: 'unmatchable_clear',
+    608: 'absorb_pierce',
 }


### PR DESCRIPTION
Order now matches the original announcement as well as Reni's blog post and also the padglobal commands and also pdchu, instead of being alphabetical randomly.