### PR TITLE
Don't edit input to token dict combiner

### DIFF
--- a/dadguide/monster_index.py
+++ b/dadguide/monster_index.py
@@ -113,6 +113,9 @@ class MonsterIndex2(aobject):
             last_token = m.name_en.split(',')[-1].strip()
             autotoken = True
 
+            for jpt in m.name_ja.split(" "):
+                self.name_tokens[jpt].add(m)
+
             # Propagate name tokens throughout all evos
             for me in self.graph.get_alt_monsters(m):
                 if last_token != me.name_en.split(',')[-1].strip():
@@ -361,10 +364,10 @@ async def sheet_to_reader(url, length=None):
 
 
 def combine_tokens_dicts(d1, *ds):
-    combined = defaultdict(set, d1)
+    combined = defaultdict(set, d1.copy())
     for d2 in ds:
         for k, v in d2.items():
-            combined[k].update(v)
+            combined[k] = combined[k].union(v)
     return combined
 
 

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 
 import discord
 import tsutils
-from Levenshtein import jaro_winkler
 from discord import Color
 from discordmenu.emoji.emoji_cache import emoji_cache
 from discordmenu.intra_message_state import IntraMessageState
@@ -27,7 +26,7 @@ from padinfo.common.emoji_map import get_attribute_emoji_by_enum, get_awakening_
 from padinfo.core import find_monster as fm
 from padinfo.core.button_info import button_info
 from padinfo.core.find_monster import find_monster, findMonster1, findMonster3, \
-    findMonsterCustom, calc_ratio_prefix
+    findMonsterCustom, calc_ratio_name, calc_ratio_modifier
 from padinfo.core.historic_lookups import historic_lookups
 from padinfo.core.leader_skills import perform_leaderskill_query
 from padinfo.core.padinfo_settings import settings
@@ -1294,8 +1293,8 @@ class PadInfo(commands.Cog):
 
         dgcog = self.bot.get_cog("Dadguide")
 
-        dist = jaro_winkler(s1, s2)
-        dist2 = calc_ratio_prefix(s1, s2, dgcog.index2)
+        dist = calc_ratio_modifier(s1, s2)
+        dist2 = calc_ratio_name(s1, s2, dgcog.index2)
         yes = '\N{WHITE HEAVY CHECK MARK}'
         no = '\N{CROSS MARK}'
         await ctx.send(f"Printing info for {inline(s1)}, {inline(s2)}\n" +


### PR DESCRIPTION
This makes sure any dicts passed into `combine_token_dicts` stay unchanged by making sure to make copies of any sets.  This fixed a bug in which all tokens that were name or fluff were added to the manual token dict which was causing almost all queries that involved manual queries to fail.

A valid test would be `blades` returning blades from kamen rider (6726).

As an unrelated feature, this PR also allows querying via JA names of cards.