### PR TITLE
Prep id for new menu (except arrow emojis)

### DIFF
--- a/padinfo/common/external_links.py
+++ b/padinfo/common/external_links.py
@@ -26,3 +26,7 @@ def skyozora(m: "MonsterModel"):
 
 def ilmina(m: "MonsterModel"):
     return ILMINA_TEMPLATE.format(m.monster_no_jp)
+
+
+def ilmina_skill(m: "MonsterModel"):
+    return "https://ilmina.com/#/SKILL/{}".format(m.active_skill.active_skill_id) if m.active_skill else None

--- a/padinfo/core/find_monster.py
+++ b/padinfo/core/find_monster.py
@@ -315,7 +315,7 @@ async def find_monster_search(tokenized_query, dgcog) -> Tuple[int, Optional["Mo
         if t not in dgcog.index2.all_modifiers:
             settings.add_typo_mod(t)
 
-    print(mod_tokens, neg_mod_tokens, name_query_tokens, neg_name_tokens)
+    # print(mod_tokens, neg_mod_tokens, name_query_tokens, neg_name_tokens)
 
     if name_query_tokens:
         monster_gen, monster_score = find_monster.process_name_tokens(name_query_tokens, neg_name_tokens, dgcog.index2)
@@ -335,7 +335,7 @@ async def find_monster_search(tokenized_query, dgcog) -> Tuple[int, Optional["Mo
         # no modifiers match any monster in the evo tree
         return 0, None
 
-    print({k: v for k, v in sorted(monster_score.items(), key=lambda kv: kv[1], reverse=True) if k in monster_gen})
+    # print({k: v for k, v in sorted(monster_score.items(), key=lambda kv: kv[1], reverse=True) if k in monster_gen})
 
     # Return most likely candidate based on query.
     mon = find_monster.get_most_eligable_monster(monster_gen, dgcog, tokenized_query, monster_score)

--- a/padinfo/core/id.py
+++ b/padinfo/core/id.py
@@ -50,6 +50,28 @@ async def perform_mats_query(dgcog, raw_query, beta_id3):
     return monster, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link
 
 
+async def perform_pic_query(dgcog, raw_query, beta_id3):
+    monster, _, _ = await findMonsterCustom2(dgcog, beta_id3, raw_query)
+    return monster
+
+
+async def perform_pantheon_query(dgcog, raw_query, beta_id3):
+    db_context = dgcog.database
+    monster, _, _ = await findMonsterCustom2(dgcog, beta_id3, raw_query)
+    full_pantheon = db_context.get_monsters_by_series(monster.series_id)
+    pantheon_list = list(filter(lambda x: db_context.graph.monster_is_base(x), full_pantheon))
+    if len(pantheon_list) == 0 or len(pantheon_list) > 20:
+        return None
+
+    series_name = monster.series.name_en
+
+    return monster, pantheon_list, series_name
+
+
+async def perform_otherinfo_query(dgcog, raw_query, beta_id3):
+    monster, _, _ = await findMonsterCustom2(dgcog, beta_id3, raw_query)
+    return monster
+
 
 async def get_monster_misc_info(db_context, monster):
     transform_base = db_context.graph.get_transform_base(monster)

--- a/padinfo/core/id.py
+++ b/padinfo/core/id.py
@@ -10,6 +10,13 @@ async def perform_id_query(dgcog, raw_query, beta_id3):
     return monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters
 
 
+async def perform_evos_query(dgcog, raw_query, beta_id3):
+    db_context = dgcog.database
+    monster, _, _ = await findMonsterCustom2(dgcog, beta_id3, raw_query)
+    alt_versions, gem_versions = await get_monster_evos_info(db_context, monster)
+    return monster, alt_versions, gem_versions
+
+
 async def get_monster_misc_info(db_context, monster):
     transform_base = db_context.graph.get_transform_base(monster)
     true_evo_type_raw = db_context.graph.true_evo_type_by_monster(monster).value
@@ -18,3 +25,10 @@ async def get_monster_misc_info(db_context, monster):
     alt_monsters = sorted({*db_context.graph.get_alt_monsters_by_id(monster.monster_no)},
                           key=lambda x: x.monster_id)
     return acquire_raw, alt_monsters, base_rarity, transform_base, true_evo_type_raw
+
+
+async def get_monster_evos_info(db_context, monster):
+    alt_versions = sorted({*db_context.graph.get_alt_monsters_by_id(monster.monster_no)},
+                          key=lambda x: x.monster_id)
+    gem_versions = list(filter(None, map(db_context.graph.evo_gem_monster, alt_versions)))
+    return alt_versions, gem_versions

--- a/padinfo/core/id.py
+++ b/padinfo/core/id.py
@@ -1,3 +1,4 @@
+from padinfo.common.external_links import ilmina_skill
 from padinfo.core.find_monster import findMonsterCustom2
 
 
@@ -15,6 +16,39 @@ async def perform_evos_query(dgcog, raw_query, beta_id3):
     monster, _, _ = await findMonsterCustom2(dgcog, beta_id3, raw_query)
     alt_versions, gem_versions = await get_monster_evos_info(db_context, monster)
     return monster, alt_versions, gem_versions
+
+
+async def perform_mats_query(dgcog, raw_query, beta_id3):
+    db_context = dgcog.database
+    monster, _, _ = await findMonsterCustom2(dgcog, beta_id3, raw_query)
+    mats = db_context.graph.evo_mats_by_monster(monster)
+    usedin = db_context.graph.material_of_monsters(monster)
+    evo_gem = db_context.graph.evo_gem_monster(monster)
+    gemid = str(evo_gem.monster_no_na) if evo_gem else None
+    gemusedin = db_context.graph.material_of_monsters(evo_gem) if evo_gem else []
+    skillups = []
+    skillup_evo_count = 0
+    link = ilmina_skill(monster)
+
+    if monster.active_skill:
+        sums = [m for m in db_context.get_monsters_by_active(monster.active_skill.active_skill_id)
+                if db_context.graph.monster_is_farmable_evo(m)]
+        sugs = [db_context.graph.evo_gem_monster(su) for su in sums]
+        vsums = []
+        for su in sums:
+            if not any(susu in vsums for susu in db_context.graph.get_alt_monsters(su)):
+                vsums.append(su)
+        skillups = [su for su in vsums
+                    if db_context.graph.monster_is_farmable_evo(su) and
+                    db_context.graph.get_base_id(su) != db_context.graph.get_base_id(monster) and
+                    su not in sugs] if monster.active_skill else []
+        skillup_evo_count = len(sums) - len(vsums)
+
+    if not any([mats, usedin, gemusedin, skillups and not monster.is_stackable]):
+        return None, None, None, None, None, None, None, None
+
+    return monster, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link
+
 
 
 async def get_monster_misc_info(db_context, monster):

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -17,6 +17,9 @@ from padinfo.view.evos import EvosView
 from padinfo.view_state.evos import EvosViewState
 from padinfo.view_state.id import IdViewState
 from padinfo.view_state.materials import MaterialsViewState
+from padinfo.view_state.otherinfo import OtherInfoViewState
+from padinfo.view_state.pantheon import PantheonViewState
+from padinfo.view_state.pic import PicViewState
 
 if TYPE_CHECKING:
     pass
@@ -27,9 +30,9 @@ emoji_button_names = [
     '\N{HOUSE BUILDING}',
     char_to_emoji('e'),
     '\N{MEAT ON BONE}',
-    # '\N{FRAME WITH PICTURE}',
-    # '\N{CLASSICAL BUILDING}',
-    # '\N{SCROLL}',
+    '\N{FRAME WITH PICTURE}',
+    '\N{CLASSICAL BUILDING}',
+    '\N{SCROLL}',
     '\N{CROSS MARK}',
 ]
 menu_emoji_config = EmbedMenuEmojiConfig(delete_message='\N{CROSS MARK}')
@@ -47,10 +50,9 @@ class IdMenu:
             IdMenu.INITIAL_EMOJI: IdMenu.respond_with_current_id,
             emoji_button_names[1]: IdMenu.respond_with_evos,
             emoji_button_names[2]: IdMenu.respond_with_mats,
-            # emoji_button_names[5]: respond_to_e,
-            emoji_button_names[6]: IdMenu.respond_with_picture,
-            # emoji_button_names[7]: respond_to_building,
-            # emoji_button_names[8]: respond_to_scroll,
+            emoji_button_names[3]: IdMenu.respond_with_picture,
+            emoji_button_names[4]: IdMenu.repond_with_pantheon,
+            emoji_button_names[5]: IdMenu.respond_with_otherinfo,
         }
 
         valid_emoji_names = [e.name for e in emoji_cache.custom_emojis] + list(transitions.keys())
@@ -123,15 +125,30 @@ class IdMenu:
 
     @staticmethod
     async def respond_with_picture(message: Optional[Message], ims, **data):
-        pass
+        dgcog = data['dgcog']
+        user_config = data['user_config']
 
-    # @staticmethod
-    # async def respond_to_building(message: Optional[Message], ims, **data):
-    #     pass
-    #
-    # @staticmethod
-    # async def respond_to_scroll(message: Optional[Message], ims, **data):
-    #     pass
+        view_state = await PicViewState.deserialize(dgcog, user_config, ims)
+        control = IdMenu.pic_control(view_state)
+        return control
+
+    @staticmethod
+    async def repond_with_pantheon(message: Optional[Message], ims, **data):
+        dgcog = data['dgcog']
+        user_config = data['user_config']
+
+        view_state = await PantheonViewState.deserialize(dgcog, user_config, ims)
+        control = IdMenu.pantheon_control(view_state)
+        return control
+
+    @staticmethod
+    async def respond_with_otherinfo(message: Optional[Message], ims, **data):
+        dgcog = data['dgcog']
+        user_config = data['user_config']
+
+        view_state = await OtherInfoViewState.deserialize(dgcog, user_config, ims)
+        control = IdMenu.otherinfo_control(view_state)
+        return control
 
     @staticmethod
     def id_control(state: IdViewState):
@@ -148,30 +165,30 @@ class IdMenu:
         )
 
     @staticmethod
-    def mats_control(state: IdViewState):
+    def mats_control(state: MaterialsViewState):
         return EmbedControl(
             [MaterialsView.embed(state)],
             [emoji_cache.get_by_name(e) for e in emoji_button_names]
         )
 
     @staticmethod
-    def pic_control(state: IdViewState):
+    def pic_control(state: PicViewState):
         return EmbedControl(
             [PicView.embed(state)],
             [emoji_cache.get_by_name(e) for e in emoji_button_names]
         )
 
-    # @staticmethod
-    # def pantheon_control(state: IdViewState):
-    #     return EmbedControl(
-    #         [PantheonView.embed(state)],
-    #         [emoji_cache.get_by_name(e) for e in emoji_button_names]
-    #     )
-    #
-    # @staticmethod
-    # def otherinfo_view(state: IdViewState):
-    #     return EmbedControl(
-    #         [OtherInfoView.embed(state)],
-    #         [emoji_cache.get_by_name(e) for e in emoji_button_names]
-    #     )
+    @staticmethod
+    def pantheon_control(state: PantheonViewState):
+        return EmbedControl(
+            [PantheonView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
+
+    @staticmethod
+    def otherinfo_control(state: OtherInfoViewState):
+        return EmbedControl(
+            [OtherInfoView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
 

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -59,7 +59,9 @@ class IdMenu:
             BotAuthoredMessageReactionFilter(bot_id),
             MessageOwnerReactionFilter(original_author_id, FriendReactionFilter(original_author_id, friend_ids))
         ]
-        return EmbedMenu(reaction_filters, transitions, IdMenu.id_control, menu_emoji_config)
+        embed = EmbedMenu(reaction_filters, transitions, IdMenu.id_control, menu_emoji_config)
+        print(embed.emoji_config.to_list())
+        return embed
 
     @staticmethod
     async def respond_to_left(message: Optional[Message], ims, **data):
@@ -111,21 +113,21 @@ class IdMenu:
         evos_control = IdMenu.evos_control(evos_view_state)
         return evos_control
 
-    @staticmethod
-    async def respond_to_bone(message: Optional[Message], ims, **data):
-        pass
-
-    @staticmethod
-    async def respond_to_picture(message: Optional[Message], ims, **data):
-        pass
-
-    @staticmethod
-    async def respond_to_building(message: Optional[Message], ims, **data):
-        pass
-
-    @staticmethod
-    async def respond_to_scroll(message: Optional[Message], ims, **data):
-        pass
+    # @staticmethod
+    # async def respond_to_bone(message: Optional[Message], ims, **data):
+    #     pass
+    #
+    # @staticmethod
+    # async def respond_to_picture(message: Optional[Message], ims, **data):
+    #     pass
+    #
+    # @staticmethod
+    # async def respond_to_building(message: Optional[Message], ims, **data):
+    #     pass
+    #
+    # @staticmethod
+    # async def respond_to_scroll(message: Optional[Message], ims, **data):
+    #     pass
 
     @staticmethod
     def id_control(state: IdViewState):
@@ -143,31 +145,31 @@ class IdMenu:
             [emoji_cache.get_by_name(e) for e in emoji_button_names]
         )
 
-    @staticmethod
-    def mats_control(state: IdViewState):
-        return EmbedControl(
-            [MaterialView.embed(state)],
-            [emoji_cache.get_by_name(e) for e in emoji_button_names]
-        )
-
-    @staticmethod
-    def pantheon_control(state: IdViewState):
-        return EmbedControl(
-            [PantheonView.embed(state)],
-            [emoji_cache.get_by_name(e) for e in emoji_button_names]
-        )
-
-    @staticmethod
-    def otherinfo_view(state: IdViewState):
-        return EmbedControl(
-            [OtherInfoView.embed(state)],
-            [emoji_cache.get_by_name(e) for e in emoji_button_names]
-        )
-
-    @staticmethod
-    def pic_control(state: IdViewState):
-        return EmbedControl(
-            [PicsView.embed(state)],
-            [emoji_cache.get_by_name(e) for e in emoji_button_names]
-        )
+    # @staticmethod
+    # def mats_control(state: IdViewState):
+    #     return EmbedControl(
+    #         [MaterialView.embed(state)],
+    #         [emoji_cache.get_by_name(e) for e in emoji_button_names]
+    #     )
+    #
+    # @staticmethod
+    # def pantheon_control(state: IdViewState):
+    #     return EmbedControl(
+    #         [PantheonView.embed(state)],
+    #         [emoji_cache.get_by_name(e) for e in emoji_button_names]
+    #     )
+    #
+    # @staticmethod
+    # def otherinfo_view(state: IdViewState):
+    #     return EmbedControl(
+    #         [OtherInfoView.embed(state)],
+    #         [emoji_cache.get_by_name(e) for e in emoji_button_names]
+    #     )
+    #
+    # @staticmethod
+    # def pic_control(state: IdViewState):
+    #     return EmbedControl(
+    #         [PicsView.embed(state)],
+    #         [emoji_cache.get_by_name(e) for e in emoji_button_names]
+    #     )
 

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -1,118 +1,163 @@
-import random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
-import discord
-from discord import Color
+from discord import Message
+from discordmenu.embed.emoji import EmbedMenuEmojiConfig
+from discordmenu.embed.menu import EmbedMenu, EmbedControl
+from discordmenu.emoji.emoji_cache import emoji_cache
+from discordmenu.reaction_filter import ValidEmojiReactionFilter, NotPosterEmojiReactionFilter, \
+    MessageOwnerReactionFilter, FriendReactionFilter, BotAuthoredMessageReactionFilter
+from tsutils import char_to_emoji
 
-from padinfo.core.id import get_monster_misc_info
-from padinfo.view.evos import EvosView
 from padinfo.view.id import IdView
-from padinfo.view.leader_skill import LeaderSkillView, LeaderSkillSingleView
-from padinfo.view.links import LinksView
-from padinfo.view.lookup import LookupView
 from padinfo.view.materials import MaterialView
 from padinfo.view.otherinfo import OtherInfoView
 from padinfo.view.pantheon import PantheonView
 from padinfo.view.pic import PicsView
+from padinfo.view.evos import EvosView
 from padinfo.view_state.id import IdViewState
 
 if TYPE_CHECKING:
-    from dadguide.database_context import DbContext
-    from dadguide.models.monster_model import MonsterModel
+    pass
+
+emoji_button_names = [
+    '\N{BLACK LEFT-POINTING TRIANGLE}',
+    '\N{BLACK RIGHT-POINTING TRIANGLE}',
+    '\N{HOUSE BUILDING}',
+    char_to_emoji('e'),
+    '\N{MEAT ON BONE}',
+    '\N{FRAME WITH PICTURE}',
+    '\N{CLASSICAL BUILDING}',
+    '\N{SCROLL}',
+    '\N{CROSS MARK}',
+]
+menu_emoji_config = EmbedMenuEmojiConfig(delete_message='\N{CROSS MARK}')
 
 
 class IdMenu:
-    def __init__(self, ctx, db_context: "DbContext" = None, allowed_emojis: list = None):
-        self.ctx = ctx
-        self.db_context = db_context
-        self.allowed_emojis = allowed_emojis
+    INITIAL_EMOJI = emoji_button_names[2]
+    MENU_TYPE = 'IdMenu'
 
-    async def get_user_embed_color(self, pdicog):
-        color = await pdicog.config.user(self.ctx.author).color()
-        if color is None:
-            return Color.default()
-        elif color == "random":
-            return Color(random.randint(0x000000, 0xffffff))
-        else:
-            return discord.Color(color)
+    @classmethod
+    def menu(cls, original_author_id, friend_ids, bot_id):
+        transitions = {
+            cls.INITIAL_EMOJI: cls.respond_to_left,
+            emoji_button_names[1]: cls.respond_to_right,
+            emoji_button_names[2]: cls.respond_to_house,
+            emoji_button_names[3]: cls.respond_to_e,
+            # emoji_button_names[4]: cls.respond_to_bone,
+            # emoji_button_names[5]: cls.respond_to_e,
+            # emoji_button_names[6]: cls.respond_to_picture,
+            # emoji_button_names[7]: cls.respond_to_building,
+            # emoji_button_names[8]: cls.respond_to_scroll,
+        }
 
-    async def make_id_embed(self, m: "MonsterModel"):
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        acquire_raw, alt_monsters, base_rarity, transform_base, true_evo_type_raw = \
-            await get_monster_misc_info(self.db_context, m)
-        state = IdViewState("", "TODO", "todo", "", m, color, transform_base, true_evo_type_raw, acquire_raw,
-                            base_rarity, alt_monsters)
-        e = IdView.embed(state)
-        return e.to_embed()
+        valid_emoji_names = [e.name for e in emoji_cache.custom_emojis] + list(transitions.keys())
+        reaction_filters = [
+            ValidEmojiReactionFilter(valid_emoji_names),
+            NotPosterEmojiReactionFilter(),
+            BotAuthoredMessageReactionFilter(bot_id),
+            MessageOwnerReactionFilter(original_author_id, FriendReactionFilter(original_author_id, friend_ids))
+        ]
 
-    async def make_evo_embed(self, m: "MonsterModel"):
-        alt_versions = self.db_context.graph.get_alt_monsters_by_id(m.monster_no)
-        gem_versions = list(filter(None, map(self.db_context.graph.evo_gem_monster, alt_versions)))
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        e = EvosView.embed(m, alt_versions, gem_versions, color)
-        return e.to_embed()
+        return EmbedMenu(reaction_filters, transitions, cls.id_control, menu_emoji_config)
 
-    async def make_evo_mats_embed(self, m: "MonsterModel"):
-        mats = self.db_context.graph.evo_mats_by_monster(m)
-        usedin = self.db_context.graph.material_of_monsters(m)
-        evo_gem = self.db_context.graph.evo_gem_monster(m)
-        gemid = str(evo_gem.monster_no_na) if evo_gem else None
-        gemusedin = self.db_context.graph.material_of_monsters(evo_gem) if evo_gem else []
-        skillups = []
-        skillup_evo_count = 0
+    @classmethod
+    async def respond_to_left(cls, message: Message, ims, **data):
+        dgcog = data['dgcog']
+        user_config = data['user_config']
 
-        if m.active_skill:
-            sums = [m for m in self.db_context.get_monsters_by_active(m.active_skill.active_skill_id)
-                    if self.db_context.graph.monster_is_farmable_evo(m)]
-            sugs = [self.db_context.graph.evo_gem_monster(su) for su in sums]
-            vsums = []
-            for su in sums:
-                if not any(susu in vsums for susu in self.db_context.graph.get_alt_monsters(su)):
-                    vsums.append(su)
-            skillups = [su for su in vsums
-                        if self.db_context.graph.monster_is_farmable_evo(su) and
-                        self.db_context.graph.get_base_id(su) != self.db_context.graph.get_base_id(m) and
-                        su not in sugs] if m.active_skill else []
-            skillup_evo_count = len(sums) - len(vsums)
+        # Extract the query from the id state
+        # TODO: let the user switch scroll modes in between then and now
+        ims['query'] = ims['left_arrow']
+        id_view_state = await IdViewState.deserialize(dgcog, user_config, ims)
+        id_control = cls.id_control(id_view_state)
+        return id_control
 
-        if not any([mats, usedin, gemusedin, skillups and not m.is_stackable]):
-            return None
-        link = "https://ilmina.com/#/SKILL/{}".format(m.active_skill.active_skill_id) if m.active_skill else None
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return MaterialView.embed(m, color, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count,
-                                  link).to_embed()
+    @classmethod
+    async def respond_to_right(cls, message: Message, ims, **data):
+        dgcog = data['dgcog']
+        user_config = data['user_config']
 
-    async def make_pantheon_embed(self, m: "MonsterModel"):
-        full_pantheon = self.db_context.get_monsters_by_series(m.series_id)
-        pantheon_list = list(filter(lambda x: self.db_context.graph.monster_is_base(x), full_pantheon))
-        if len(pantheon_list) == 0 or len(pantheon_list) > 20:
-            return None
+        # Extract the query from the id state
+        # TODO: let the user switch scroll modes in between then and now
+        ims['query'] = ims['right_arrow']
+        id_view_state = await IdViewState.deserialize(dgcog, user_config, ims)
+        id_control = cls.id_control(id_view_state)
+        return id_control
 
-        series_name = m.series.name_en
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return PantheonView.embed(m, color, pantheon_list, series_name).to_embed()
+    @classmethod
+    async def respond_to_house(cls, message: Optional[Message], ims, **data):
+        dgcog = data['dgcog']
+        user_config = data['user_config']
 
-    async def make_picture_embed(self, m: "MonsterModel"):
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return PicsView.embed(m, color).to_embed()
+        id_view_state = await IdViewState.deserialize(dgcog, user_config, ims)
+        id_control = cls.id_control(id_view_state)
+        return id_control
 
-    async def make_ls_embed(self, left_m: "MonsterModel", right_m: "MonsterModel"):
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        embed = LeaderSkillView.embed(left_m, right_m, color)
-        return embed.to_embed()
+    @classmethod
+    async def respond_to_e(cls, message: Message, ims, **data):
+        dgcog = data['dgcog']
+        user_config = data['user_config']
 
-    async def make_lookup_embed(self, m: "MonsterModel"):
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return LookupView.embed(m, color).to_embed()
+        id_view_state = await IdViewState.deserialize(dgcog, user_config, ims)
+        id_control = cls.evos_control(id_view_state)
+        return id_control
 
-    async def make_otherinfo_embed(self, m: "MonsterModel"):
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return OtherInfoView.embed(m, color).to_embed()
+    @classmethod
+    async def respond_to_bone(cls, message: Message, ims, **data):
+        pass
 
-    async def make_links_embed(self, m: "MonsterModel"):
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return LinksView.embed(m, color).to_embed()
+    @classmethod
+    async def respond_to_picture(cls, message: Message, ims, **data):
+        pass
 
-    async def make_lssingle_embed(self, m: "MonsterModel"):
-        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return LeaderSkillSingleView.embed(m, color).to_embed()
+    @classmethod
+    async def respond_to_building(cls, message: Message, ims, **data):
+        pass
+
+    @classmethod
+    async def respond_to_scroll(cls, message: Message, ims, **data):
+        pass
+
+    @staticmethod
+    def evos_control(state: IdViewState):
+        return EmbedControl(
+            [EvosView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
+
+    @staticmethod
+    def id_control(state: IdViewState):
+        return EmbedControl(
+            [IdView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
+
+    @staticmethod
+    def mats_control(state: IdViewState):
+        return EmbedControl(
+            [MaterialView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
+
+    @staticmethod
+    def pantheon_control(state: IdViewState):
+        return EmbedControl(
+            [PantheonView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
+
+    @staticmethod
+    def otherinfo_view(state: IdViewState):
+        return EmbedControl(
+            [OtherInfoView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
+
+    @staticmethod
+    def pic_control(state: IdViewState):
+        return EmbedControl(
+            [PicsView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
+

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -9,13 +9,14 @@ from discordmenu.reaction_filter import ValidEmojiReactionFilter, NotPosterEmoji
 from tsutils import char_to_emoji
 
 from padinfo.view.id import IdView
-from padinfo.view.materials import MaterialView
+from padinfo.view.materials import MaterialsView
 from padinfo.view.otherinfo import OtherInfoView
 from padinfo.view.pantheon import PantheonView
-from padinfo.view.pic import PicsView
+from padinfo.view.pic import PicView
 from padinfo.view.evos import EvosView
 from padinfo.view_state.evos import EvosViewState
 from padinfo.view_state.id import IdViewState
+from padinfo.view_state.materials import MaterialsViewState
 
 if TYPE_CHECKING:
     pass
@@ -25,7 +26,7 @@ emoji_button_names = [
     # '\N{BLACK RIGHT-POINTING TRIANGLE}',
     '\N{HOUSE BUILDING}',
     char_to_emoji('e'),
-    # '\N{MEAT ON BONE}',
+    '\N{MEAT ON BONE}',
     # '\N{FRAME WITH PICTURE}',
     # '\N{CLASSICAL BUILDING}',
     # '\N{SCROLL}',
@@ -43,11 +44,11 @@ class IdMenu:
         transitions = {
             # emoji_button_names[0]: respond_to_left,
             # emoji_button_names[1]: respond_to_right,
-            IdMenu.INITIAL_EMOJI: IdMenu.respond_to_house,
-            emoji_button_names[1]: IdMenu.respond_to_e,
-            # emoji_button_names[4]: respond_to_bone,
+            IdMenu.INITIAL_EMOJI: IdMenu.respond_with_current_id,
+            emoji_button_names[1]: IdMenu.respond_with_evos,
+            emoji_button_names[2]: IdMenu.respond_with_mats,
             # emoji_button_names[5]: respond_to_e,
-            # emoji_button_names[6]: respond_to_picture,
+            emoji_button_names[6]: IdMenu.respond_with_picture,
             # emoji_button_names[7]: respond_to_building,
             # emoji_button_names[8]: respond_to_scroll,
         }
@@ -60,7 +61,6 @@ class IdMenu:
             MessageOwnerReactionFilter(original_author_id, FriendReactionFilter(original_author_id, friend_ids))
         ]
         embed = EmbedMenu(reaction_filters, transitions, IdMenu.id_control, menu_emoji_config)
-        print(embed.emoji_config.to_list())
         return embed
 
     @staticmethod
@@ -95,32 +95,36 @@ class IdMenu:
         pass
 
     @staticmethod
-    async def respond_to_house(message: Optional[Message], ims, **data):
+    async def respond_with_current_id(message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
         user_config = data['user_config']
 
-        id_view_state = await IdViewState.deserialize(dgcog, user_config, ims)
-        id_control = IdMenu.id_control(id_view_state)
-        return id_control
+        view_state = await IdViewState.deserialize(dgcog, user_config, ims)
+        control = IdMenu.id_control(view_state)
+        return control
 
     @staticmethod
-    async def respond_to_e(message: Optional[Message], ims, **data):
-        print('hello')
+    async def respond_with_evos(message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
         user_config = data['user_config']
 
-        evos_view_state = await EvosViewState.deserialize(dgcog, user_config, ims)
-        evos_control = IdMenu.evos_control(evos_view_state)
-        return evos_control
+        view_state = await EvosViewState.deserialize(dgcog, user_config, ims)
+        control = IdMenu.evos_control(view_state)
+        return control
 
-    # @staticmethod
-    # async def respond_to_bone(message: Optional[Message], ims, **data):
-    #     pass
-    #
-    # @staticmethod
-    # async def respond_to_picture(message: Optional[Message], ims, **data):
-    #     pass
-    #
+    @staticmethod
+    async def respond_with_mats(message: Optional[Message], ims, **data):
+        dgcog = data['dgcog']
+        user_config = data['user_config']
+
+        view_state = await MaterialsViewState.deserialize(dgcog, user_config, ims)
+        control = IdMenu.mats_control(view_state)
+        return control
+
+    @staticmethod
+    async def respond_with_picture(message: Optional[Message], ims, **data):
+        pass
+
     # @staticmethod
     # async def respond_to_building(message: Optional[Message], ims, **data):
     #     pass
@@ -138,20 +142,25 @@ class IdMenu:
 
     @staticmethod
     def evos_control(state: EvosViewState):
-        print('hi here')
-        print(state)
         return EmbedControl(
             [EvosView.embed(state)],
             [emoji_cache.get_by_name(e) for e in emoji_button_names]
         )
 
-    # @staticmethod
-    # def mats_control(state: IdViewState):
-    #     return EmbedControl(
-    #         [MaterialView.embed(state)],
-    #         [emoji_cache.get_by_name(e) for e in emoji_button_names]
-    #     )
-    #
+    @staticmethod
+    def mats_control(state: IdViewState):
+        return EmbedControl(
+            [MaterialsView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
+
+    @staticmethod
+    def pic_control(state: IdViewState):
+        return EmbedControl(
+            [PicView.embed(state)],
+            [emoji_cache.get_by_name(e) for e in emoji_button_names]
+        )
+
     # @staticmethod
     # def pantheon_control(state: IdViewState):
     #     return EmbedControl(
@@ -163,13 +172,6 @@ class IdMenu:
     # def otherinfo_view(state: IdViewState):
     #     return EmbedControl(
     #         [OtherInfoView.embed(state)],
-    #         [emoji_cache.get_by_name(e) for e in emoji_button_names]
-    #     )
-    #
-    # @staticmethod
-    # def pic_control(state: IdViewState):
-    #     return EmbedControl(
-    #         [PicsView.embed(state)],
     #         [emoji_cache.get_by_name(e) for e in emoji_button_names]
     #     )
 

--- a/padinfo/id_menu_old.py
+++ b/padinfo/id_menu_old.py
@@ -10,12 +10,13 @@ from padinfo.view.id import IdView
 from padinfo.view.leader_skill import LeaderSkillView, LeaderSkillSingleView
 from padinfo.view.links import LinksView
 from padinfo.view.lookup import LookupView
-from padinfo.view.materials import MaterialView
+from padinfo.view.materials import MaterialsView
 from padinfo.view.otherinfo import OtherInfoView
 from padinfo.view.pantheon import PantheonView
-from padinfo.view.pic import PicsView
+from padinfo.view.pic import PicView
 from padinfo.view_state.evos import EvosViewState
 from padinfo.view_state.id import IdViewState
+from padinfo.view_state.materials import MaterialsViewState
 
 if TYPE_CHECKING:
     from dadguide.database_context import DbContext
@@ -81,8 +82,11 @@ class IdMenu:
             return None
         link = "https://ilmina.com/#/SKILL/{}".format(m.active_skill.active_skill_id) if m.active_skill else None
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return MaterialView.embed(m, color, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count,
-                                  link).to_embed()
+
+        state = MaterialsViewState("", "TODO", "todo", "", m, color, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count,
+                                   link)
+
+        return MaterialsView.embed(state).to_embed()
 
     async def make_pantheon_embed(self, m: "MonsterModel"):
         full_pantheon = self.db_context.get_monsters_by_series(m.series_id)
@@ -96,7 +100,7 @@ class IdMenu:
 
     async def make_picture_embed(self, m: "MonsterModel"):
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return PicsView.embed(m, color).to_embed()
+        return PicView.embed(m, color).to_embed()
 
     async def make_ls_embed(self, left_m: "MonsterModel", right_m: "MonsterModel"):
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))

--- a/padinfo/id_menu_old.py
+++ b/padinfo/id_menu_old.py
@@ -17,6 +17,9 @@ from padinfo.view.pic import PicView
 from padinfo.view_state.evos import EvosViewState
 from padinfo.view_state.id import IdViewState
 from padinfo.view_state.materials import MaterialsViewState
+from padinfo.view_state.otherinfo import OtherInfoViewState
+from padinfo.view_state.pantheon import PantheonViewState
+from padinfo.view_state.pic import PicViewState
 
 if TYPE_CHECKING:
     from dadguide.database_context import DbContext
@@ -42,7 +45,7 @@ class IdMenu:
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
         acquire_raw, alt_monsters, base_rarity, transform_base, true_evo_type_raw = \
             await get_monster_misc_info(self.db_context, m)
-        state = IdViewState("", "TODO", "todo", "", m, color, transform_base, true_evo_type_raw, acquire_raw,
+        state = IdViewState("", "TODO", "todo", "", color, m, transform_base, true_evo_type_raw, acquire_raw,
                             base_rarity, alt_monsters)
         e = IdView.embed(state)
         return e.to_embed()
@@ -51,7 +54,7 @@ class IdMenu:
         alt_versions = self.db_context.graph.get_alt_monsters_by_id(m.monster_no)
         gem_versions = list(filter(None, map(self.db_context.graph.evo_gem_monster, alt_versions)))
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        state = EvosViewState("", "TODO", "todo", "", m, alt_versions, gem_versions, color)
+        state = EvosViewState("", "TODO", "todo", "", color, m, alt_versions, gem_versions)
         e = EvosView.embed(state)
         return e.to_embed()
 
@@ -83,7 +86,7 @@ class IdMenu:
         link = "https://ilmina.com/#/SKILL/{}".format(m.active_skill.active_skill_id) if m.active_skill else None
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
 
-        state = MaterialsViewState("", "TODO", "todo", "", m, color, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count,
+        state = MaterialsViewState("", "TODO", "todo", "", color, m, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count,
                                    link)
 
         return MaterialsView.embed(state).to_embed()
@@ -96,11 +99,13 @@ class IdMenu:
 
         series_name = m.series.name_en
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return PantheonView.embed(m, color, pantheon_list, series_name).to_embed()
+        state = PantheonViewState('', '', '', '', color, m, pantheon_list, series_name)
+        return PantheonView.embed(state).to_embed()
 
     async def make_picture_embed(self, m: "MonsterModel"):
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return PicView.embed(m, color).to_embed()
+        state = PicViewState('', '', '', '', color, m)
+        return PicView.embed(state).to_embed()
 
     async def make_ls_embed(self, left_m: "MonsterModel", right_m: "MonsterModel"):
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
@@ -113,7 +118,8 @@ class IdMenu:
 
     async def make_otherinfo_embed(self, m: "MonsterModel"):
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
-        return OtherInfoView.embed(m, color).to_embed()
+        state = OtherInfoViewState('', '', '', '', color, m)
+        return OtherInfoView.embed(state).to_embed()
 
     async def make_links_embed(self, m: "MonsterModel"):
         color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))

--- a/padinfo/id_menu_old.py
+++ b/padinfo/id_menu_old.py
@@ -1,0 +1,120 @@
+import random
+from typing import TYPE_CHECKING
+
+import discord
+from discord import Color
+
+from padinfo.core.id import get_monster_misc_info
+from padinfo.view.evos import EvosView
+from padinfo.view.id import IdView
+from padinfo.view.leader_skill import LeaderSkillView, LeaderSkillSingleView
+from padinfo.view.links import LinksView
+from padinfo.view.lookup import LookupView
+from padinfo.view.materials import MaterialView
+from padinfo.view.otherinfo import OtherInfoView
+from padinfo.view.pantheon import PantheonView
+from padinfo.view.pic import PicsView
+from padinfo.view_state.evos import EvosViewState
+from padinfo.view_state.id import IdViewState
+
+if TYPE_CHECKING:
+    from dadguide.database_context import DbContext
+    from dadguide.models.monster_model import MonsterModel
+
+
+class IdMenu:
+    def __init__(self, ctx, db_context: "DbContext" = None, allowed_emojis: list = None):
+        self.ctx = ctx
+        self.db_context = db_context
+        self.allowed_emojis = allowed_emojis
+
+    async def get_user_embed_color(self, pdicog):
+        color = await pdicog.config.user(self.ctx.author).color()
+        if color is None:
+            return Color.default()
+        elif color == "random":
+            return Color(random.randint(0x000000, 0xffffff))
+        else:
+            return discord.Color(color)
+
+    async def make_id_embed(self, m: "MonsterModel"):
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        acquire_raw, alt_monsters, base_rarity, transform_base, true_evo_type_raw = \
+            await get_monster_misc_info(self.db_context, m)
+        state = IdViewState("", "TODO", "todo", "", m, color, transform_base, true_evo_type_raw, acquire_raw,
+                            base_rarity, alt_monsters)
+        e = IdView.embed(state)
+        return e.to_embed()
+
+    async def make_evo_embed(self, m: "MonsterModel"):
+        alt_versions = self.db_context.graph.get_alt_monsters_by_id(m.monster_no)
+        gem_versions = list(filter(None, map(self.db_context.graph.evo_gem_monster, alt_versions)))
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        state = EvosViewState("", "TODO", "todo", "", m, alt_versions, gem_versions, color)
+        e = EvosView.embed(state)
+        return e.to_embed()
+
+    async def make_evo_mats_embed(self, m: "MonsterModel"):
+        mats = self.db_context.graph.evo_mats_by_monster(m)
+        usedin = self.db_context.graph.material_of_monsters(m)
+        evo_gem = self.db_context.graph.evo_gem_monster(m)
+        gemid = str(evo_gem.monster_no_na) if evo_gem else None
+        gemusedin = self.db_context.graph.material_of_monsters(evo_gem) if evo_gem else []
+        skillups = []
+        skillup_evo_count = 0
+
+        if m.active_skill:
+            sums = [m for m in self.db_context.get_monsters_by_active(m.active_skill.active_skill_id)
+                    if self.db_context.graph.monster_is_farmable_evo(m)]
+            sugs = [self.db_context.graph.evo_gem_monster(su) for su in sums]
+            vsums = []
+            for su in sums:
+                if not any(susu in vsums for susu in self.db_context.graph.get_alt_monsters(su)):
+                    vsums.append(su)
+            skillups = [su for su in vsums
+                        if self.db_context.graph.monster_is_farmable_evo(su) and
+                        self.db_context.graph.get_base_id(su) != self.db_context.graph.get_base_id(m) and
+                        su not in sugs] if m.active_skill else []
+            skillup_evo_count = len(sums) - len(vsums)
+
+        if not any([mats, usedin, gemusedin, skillups and not m.is_stackable]):
+            return None
+        link = "https://ilmina.com/#/SKILL/{}".format(m.active_skill.active_skill_id) if m.active_skill else None
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        return MaterialView.embed(m, color, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count,
+                                  link).to_embed()
+
+    async def make_pantheon_embed(self, m: "MonsterModel"):
+        full_pantheon = self.db_context.get_monsters_by_series(m.series_id)
+        pantheon_list = list(filter(lambda x: self.db_context.graph.monster_is_base(x), full_pantheon))
+        if len(pantheon_list) == 0 or len(pantheon_list) > 20:
+            return None
+
+        series_name = m.series.name_en
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        return PantheonView.embed(m, color, pantheon_list, series_name).to_embed()
+
+    async def make_picture_embed(self, m: "MonsterModel"):
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        return PicsView.embed(m, color).to_embed()
+
+    async def make_ls_embed(self, left_m: "MonsterModel", right_m: "MonsterModel"):
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        embed = LeaderSkillView.embed(left_m, right_m, color)
+        return embed.to_embed()
+
+    async def make_lookup_embed(self, m: "MonsterModel"):
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        return LookupView.embed(m, color).to_embed()
+
+    async def make_otherinfo_embed(self, m: "MonsterModel"):
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        return OtherInfoView.embed(m, color).to_embed()
+
+    async def make_links_embed(self, m: "MonsterModel"):
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        return LinksView.embed(m, color).to_embed()
+
+    async def make_lssingle_embed(self, m: "MonsterModel"):
+        color = await self.get_user_embed_color(self.ctx.bot.get_cog("PadInfo"))
+        return LeaderSkillSingleView.embed(m, color).to_embed()

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -184,12 +184,13 @@ class PadInfo(commands.Cog):
         #     await self._do_id3(ctx, query)
         # else:
         #     await self._do_id(ctx, query)
+
         dgcog = await self.get_dgcog()
         raw_query = query
         color = await self.get_user_embed_color(ctx)
         original_author_id = ctx.message.author.id
         friend_cog = self.bot.get_cog("Friend")
-        friends = friend_cog and (await friend_cog.get_friends(original_author_id))
+        friends = (await friend_cog.get_friends(original_author_id)) if friend_cog else []
         monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters = \
             await perform_id_query(dgcog, raw_query, await self.config.user(ctx.author).beta_id3())
         state = IdViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query,

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -190,23 +190,23 @@ class PadInfo(commands.Cog):
     @checks.bot_has_permissions(embed_links=True)
     async def _id(self, ctx, *, query: str):
         """Monster info (main tab)"""
-        # if await self.config.user(ctx.author).beta_id3():
-        #     await self._do_id3(ctx, query)
-        # else:
-        #     await self._do_id(ctx, query)
+        if await self.config.user(ctx.author).beta_id3():
+            await self._do_id3(ctx, query)
+        else:
+            await self._do_id(ctx, query)
 
-        dgcog = await self.get_dgcog()
-        raw_query = query
-        color = await self.get_user_embed_color(ctx)
-        original_author_id = ctx.message.author.id
-        friend_cog = self.bot.get_cog("Friend")
-        friends = (await friend_cog.get_friends(original_author_id)) if friend_cog else []
-        monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters = \
-            await perform_id_query(dgcog, raw_query, await self.config.user(ctx.author).beta_id3())
-        state = IdViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
-                            monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters)
-        menu = IdMenu.menu(original_author_id, friends, self.bot.user.id)
-        await menu.create(ctx, state)
+        # dgcog = await self.get_dgcog()
+        # raw_query = query
+        # color = await self.get_user_embed_color(ctx)
+        # original_author_id = ctx.message.author.id
+        # friend_cog = self.bot.get_cog("Friend")
+        # friends = (await friend_cog.get_friends(original_author_id)) if friend_cog else []
+        # monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters = \
+        #     await perform_id_query(dgcog, raw_query, await self.config.user(ctx.author).beta_id3())
+        # state = IdViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
+        #                     monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters)
+        # menu = IdMenu.menu(original_author_id, friends, self.bot.user.id)
+        # await menu.create(ctx, state)
 
     @commands.command(aliases=["idold", "oldid"])
     @checks.bot_has_permissions(embed_links=True)

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -203,8 +203,8 @@ class PadInfo(commands.Cog):
         friends = (await friend_cog.get_friends(original_author_id)) if friend_cog else []
         monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters = \
             await perform_id_query(dgcog, raw_query, await self.config.user(ctx.author).beta_id3())
-        state = IdViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query,
-                            monster, color, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters)
+        state = IdViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
+                            monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters)
         menu = IdMenu.menu(original_author_id, friends, self.bot.user.id)
         await menu.create(ctx, state)
 
@@ -780,7 +780,7 @@ class PadInfo(commands.Cog):
         cases = re.findall(r'\s*(?:\d+. )?(.+?) + - (\d+)\s+(\w*) *(.*)', queries)
         async with self.config.fluff_suite() as suite:
             for query, result, fluff, reason in cases:
-                print(query, result, fluff, reason)
+                # print(query, result, fluff, reason)
                 if not any(c['id'] == int(result) and c['token'] == query for c in suite):
                     suite.append({
                         'id': int(result),

--- a/padinfo/view/evos.py
+++ b/padinfo/view/evos.py
@@ -1,18 +1,12 @@
-from typing import TYPE_CHECKING
-
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedThumbnail, EmbedMain, EmbedField
 from discordmenu.embed.view import EmbedView
 
 from padinfo.common.external_links import puzzledragonx
-from padinfo.view.components.base import pad_info_footer
+from padinfo.view.components.base import pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
-
 from padinfo.view_state.evos import EvosViewState
-
-if TYPE_CHECKING:
-    from dadguide.models.monster_model import MonsterModel
 
 
 def _evo_lines(monsters, current_monster):
@@ -44,5 +38,5 @@ class EvosView:
                 title=MonsterHeader.long_v2(state.monster).to_markdown(),
                 url=puzzledragonx(state.monster)),
             embed_thumbnail=EmbedThumbnail(MonsterImage.icon(state.monster)),
-            embed_footer=pad_info_footer(),
+            embed_footer=pad_info_footer_with_state(state),
             embed_fields=fields)

--- a/padinfo/view/evos.py
+++ b/padinfo/view/evos.py
@@ -9,6 +9,8 @@ from padinfo.view.components.base import pad_info_footer
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
 
+from padinfo.view_state.evos import EvosViewState
+
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
@@ -24,23 +26,23 @@ def _evo_lines(monsters, current_monster):
 
 class EvosView:
     @staticmethod
-    def embed(m: "MonsterModel", alt_versions, gem_versions, color):
+    def embed(state: EvosViewState):
         fields = [
             EmbedField(
-                ("{} evolution" if len(alt_versions) == 1 else "{} evolutions").format(len(alt_versions)),
-                Box(*_evo_lines(alt_versions, m)))]
+                ("{} evolution" if len(state.alt_versions) == 1 else "{} evolutions").format(len(state.alt_versions)),
+                Box(*_evo_lines(state.alt_versions, state.monster)))]
 
-        if gem_versions:
+        if state.gem_versions:
             fields.append(
                 EmbedField(
-                    ("{} evolve gem" if len(gem_versions) == 1 else "{} evolve gems").format(len(gem_versions)),
-                    Box(*_evo_lines(gem_versions, m))))
+                    ("{} evolve gem" if len(state.gem_versions) == 1 else "{} evolve gems").format(len(state.gem_versions)),
+                    Box(*_evo_lines(state.gem_versions, state.monster))))
 
         return EmbedView(
             EmbedMain(
-                color=color,
-                title=MonsterHeader.long_v2(m).to_markdown(),
-                url=puzzledragonx(m)),
-            embed_thumbnail=EmbedThumbnail(MonsterImage.icon(m)),
+                color=state.color,
+                title=MonsterHeader.long_v2(state.monster).to_markdown(),
+                url=puzzledragonx(state.monster)),
+            embed_thumbnail=EmbedThumbnail(MonsterImage.icon(state.monster)),
             embed_footer=pad_info_footer(),
             embed_fields=fields)

--- a/padinfo/view/materials.py
+++ b/padinfo/view/materials.py
@@ -6,9 +6,10 @@ from discordmenu.embed.view import EmbedView
 from discordmenu.embed.text import LinkedText
 
 from padinfo.common.external_links import puzzledragonx
-from padinfo.view.components.base import pad_info_footer
+from padinfo.view.components.base import pad_info_footer, pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
+from padinfo.view_state.materials import MaterialsViewState
 
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
@@ -47,21 +48,22 @@ def skillup_field(mons, sec, link):
         Box(*(MonsterHeader.short_with_emoji(em) for em in mons[:MAX_MONS_TO_SHOW]), text, text2))
 
 
-class MaterialView:
+class MaterialsView:
     @staticmethod
-    def embed(m: "MonsterModel", color, mats, usedin, gemid, gemusedin, skillups, sec, link):
+    def embed(state: MaterialsViewState):
+        # m: "MonsterModel", color, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link
         return EmbedView(
             EmbedMain(
-                color=color,
-                title=MonsterHeader.long_v2(m).to_markdown(),
-                url=puzzledragonx(m)
+                color=state.color,
+                title=MonsterHeader.long_v2(state.monster).to_markdown(),
+                url=puzzledragonx(state.monster)
             ),
-            embed_thumbnail=EmbedThumbnail(MonsterImage.icon(m)),
-            embed_footer=pad_info_footer(),
+            embed_thumbnail=EmbedThumbnail(MonsterImage.icon(state.monster)),
+            embed_footer=pad_info_footer_with_state(state),
             embed_fields=[f for f in [
-                mat_use_field(mats, "Evo materials") if mats or not m.is_stackable else None,
-                mat_use_field(usedin, "Material for", 10) if usedin else None,
-                mat_use_field(gemusedin, "Evo gem ({}) is mat for".format(gemid)) if gemusedin else None,
-                skillup_field(skillups, sec, link) if not m.is_stackable else None
+                mat_use_field(state.mats, "Evo materials") if state.mats or not state.monster.is_stackable else None,
+                mat_use_field(state.usedin, "Material for", 10) if state.usedin else None,
+                mat_use_field(state.gemusedin, "Evo gem ({}) is mat for".format(state.gemid)) if state.gemusedin else None,
+                skillup_field(state.skillups, state.skillup_evo_count, state.link) if not state.monster.is_stackable else None
             ] if f is not None]
         )

--- a/padinfo/view/otherinfo.py
+++ b/padinfo/view/otherinfo.py
@@ -8,9 +8,10 @@ from discordmenu.embed.text import LabeledText, LinkedText, Text
 from redbot.core.utils.chat_formatting import box
 
 from padinfo.common.external_links import puzzledragonx, youtube_search, skyozora, ilmina
-from padinfo.view.components.base import pad_info_footer
+from padinfo.view.components.base import pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.links import LinksView
+from padinfo.view_state.otherinfo import OtherInfoViewState
 
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
@@ -33,13 +34,14 @@ def statsbox(m):
 
 class OtherInfoView:
     @staticmethod
-    def embed(m: "MonsterModel", color):
+    def embed(state: OtherInfoViewState):
+        m = state.monster
         return EmbedView(
             EmbedMain(
-                color=color,
+                color=state.color,
                 title=MonsterHeader.long_v2(m).to_markdown(),
                 url=puzzledragonx(m)),
-            embed_footer=pad_info_footer(),
+            embed_footer=pad_info_footer_with_state(state),
             embed_fields=[
                 EmbedField(
                     "Stats at +297:",

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -1,35 +1,31 @@
-from typing import TYPE_CHECKING
-
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedMain, EmbedField, EmbedThumbnail
 from discordmenu.embed.view import EmbedView
 
 from padinfo.common.external_links import puzzledragonx
-from padinfo.view.components.base import pad_info_footer
+from padinfo.view.components.base import pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
-
-if TYPE_CHECKING:
-    from dadguide.models.monster_model import MonsterModel
+from padinfo.view_state.pantheon import PantheonViewState
 
 
 class PantheonView:
     @staticmethod
-    def embed(m: "MonsterModel", color, pantheon_list, series_name):
+    def embed(state: PantheonViewState):
         fields = [EmbedField(
-            'Pantheon: {}'.format(series_name),
+            'Pantheon: {}'.format(state.series_name),
             Box(
                 *[MonsterHeader.short_with_emoji(m)
-                  for m in sorted(pantheon_list, key=lambda x: x.monster_no_na)]
+                  for m in sorted(state.pantheon_list, key=lambda x: x.monster_no_na)]
             )
         )]
 
         return EmbedView(
             EmbedMain(
-                color=color,
-                title=MonsterHeader.long_v2(m).to_markdown(),
-                url=puzzledragonx(m)),
-            embed_footer=pad_info_footer(),
+                color=state.color,
+                title=MonsterHeader.long_v2(state.monster).to_markdown(),
+                url=puzzledragonx(state.monster)),
+            embed_footer=pad_info_footer_with_state(state),
             embed_fields=fields,
-            embed_thumbnail=EmbedThumbnail(MonsterImage.icon(m)),
+            embed_thumbnail=EmbedThumbnail(MonsterImage.icon(state.monster)),
         )

--- a/padinfo/view/pic.py
+++ b/padinfo/view/pic.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
 
-class PicsView:
+class PicView:
     @staticmethod
     def embed(m: "MonsterModel", color):
         url = MonsterImage.picture(m)

--- a/padinfo/view/pic.py
+++ b/padinfo/view/pic.py
@@ -1,50 +1,46 @@
-from typing import TYPE_CHECKING
-
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedMain, EmbedField, EmbedBodyImage
 from discordmenu.embed.view import EmbedView
 from discordmenu.embed.text import LinkedText, Text
 
 from padinfo.common.external_links import puzzledragonx
-from padinfo.view.components.base import pad_info_footer
+from padinfo.view.components.base import pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
-
-if TYPE_CHECKING:
-    from dadguide.models.monster_model import MonsterModel
+from padinfo.view_state.pic import PicViewState
 
 
 class PicView:
     @staticmethod
-    def embed(m: "MonsterModel", color):
-        url = MonsterImage.picture(m)
-        animated = m.has_animation
+    def embed(state: PicViewState):
+        url = MonsterImage.picture(state.monster)
+        animated = state.monster.has_animation
         fields = [EmbedField(
             'Extra Links',
             Box(
                 Box(
                     Text('Animation:'),
-                    LinkedText('(MP4)', MonsterImage.video(m)),
+                    LinkedText('(MP4)', MonsterImage.video(state.monster)),
                     Text('|'),
-                    LinkedText('(GIF)', MonsterImage.gif(m)),
+                    LinkedText('(GIF)', MonsterImage.gif(state.monster)),
                     delimiter=' '
                 ) if animated else None,
                 Box(
                     Text('Orb Skin:'),
-                    LinkedText('Regular', MonsterImage.orb_skin(m)),
+                    LinkedText('Regular', MonsterImage.orb_skin(state.monster)),
                     Text('|'),
-                    LinkedText('Color Blind', MonsterImage.orb_skin_colorblind(m)),
+                    LinkedText('Color Blind', MonsterImage.orb_skin_colorblind(state.monster)),
                     delimiter=' '
-                ) if m.orb_skin_id else None,
+                ) if state.monster.orb_skin_id else None,
             )
         )]
 
         return EmbedView(
             EmbedMain(
-                color=color,
-                title=MonsterHeader.long_v2(m).to_markdown(),
-                url=puzzledragonx(m)),
-            embed_footer=pad_info_footer(),
+                color=state.color,
+                title=MonsterHeader.long_v2(state.monster).to_markdown(),
+                url=puzzledragonx(state.monster)),
+            embed_footer=pad_info_footer_with_state(state),
             embed_fields=fields,
             embed_body_image=EmbedBodyImage(url),
         )

--- a/padinfo/view_state/evos.py
+++ b/padinfo/view_state/evos.py
@@ -1,0 +1,43 @@
+from typing import List, TYPE_CHECKING
+
+from padinfo.common.config import UserConfig
+from padinfo.core.id import perform_evos_query
+from padinfo.view_state.base import ViewState
+
+if TYPE_CHECKING:
+    from dadguide.models.monster_model import MonsterModel
+
+
+class EvosViewState(ViewState):
+    def __init__(self, original_author_id, menu_type, raw_query, query, monster: "MonsterModel",
+                 alt_versions: List["MonsterModel"], gem_versions: List["MonsterModel"], color,
+                 extra_state=None):
+        super().__init__(original_author_id, menu_type, raw_query, extra_state=extra_state)
+        self.alt_versions = alt_versions
+        self.gem_versions = gem_versions
+        self.query = query
+        self.monster = monster
+        self.color = color
+
+    def serialize(self):
+        ret = super().serialize()
+        ret.update({
+            'query': self.query,
+            'resolved_monster_id': self.monster.monster_id
+        })
+        return ret
+
+    @classmethod
+    async def deserialize(cls, dgcog, user_config: UserConfig, ims: dict):
+        raw_query = ims['raw_query']
+
+        original_author_id = ims['original_author_id']
+
+        menu_type = ims['menu_type']
+
+        query = ims.get('query') or raw_query
+
+        monster, alt_versions, gem_versions = await perform_evos_query(dgcog, query, user_config.beta_id3)
+
+        return cls(original_author_id, menu_type, raw_query, query, monster,
+                   alt_versions, gem_versions, user_config.color, extra_state=ims)

--- a/padinfo/view_state/id.py
+++ b/padinfo/view_state/id.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 class IdViewState(ViewState):
-    def __init__(self, original_author_id, menu_type, raw_query, query, monster: "MonsterModel", color,
+    def __init__(self, original_author_id, menu_type, raw_query, query, color, monster: "MonsterModel",
                  transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters: List["MonsterModel"],
                  extra_state=None):
         super().__init__(original_author_id, menu_type, raw_query, extra_state=extra_state)
@@ -43,6 +43,6 @@ class IdViewState(ViewState):
         monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters = \
             await perform_id_query(dgcog, query, user_config.beta_id3)
 
-        return IdViewState(original_author_id, menu_type, raw_query, query, monster, user_config.color,
+        return IdViewState(original_author_id, menu_type, raw_query, query, user_config.color, monster,
                            transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters,
                            extra_state=ims)

--- a/padinfo/view_state/materials.py
+++ b/padinfo/view_state/materials.py
@@ -1,20 +1,26 @@
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, Optional
 
 from padinfo.common.config import UserConfig
-from padinfo.core.id import perform_evos_query
+from padinfo.core.id import perform_mats_query
 from padinfo.view_state.base import ViewState
 
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
 
-class EvosViewState(ViewState):
+class MaterialsViewState(ViewState):
     def __init__(self, original_author_id, menu_type, raw_query, query, color, monster: "MonsterModel",
-                 alt_versions: List["MonsterModel"], gem_versions: List["MonsterModel"],
+                 mats: List["MonsterModel"], usedin: List["MonsterModel"], gemid: Optional[str],
+                 gemusedin: List["MonsterModel"], skillups: List["MonsterModel"], skillup_evo_count: int, link: str,
                  extra_state=None):
         super().__init__(original_author_id, menu_type, raw_query, extra_state=extra_state)
-        self.alt_versions = alt_versions
-        self.gem_versions = gem_versions
+        self.link = link
+        self.skillup_evo_count = skillup_evo_count
+        self.skillups = skillups
+        self.gemusedin = gemusedin
+        self.mats = mats
+        self.usedin = usedin
+        self.gemid = gemid
         self.query = query
         self.monster = monster
         self.color = color
@@ -37,7 +43,7 @@ class EvosViewState(ViewState):
 
         query = ims.get('query') or raw_query
 
-        monster, alt_versions, gem_versions = await perform_evos_query(dgcog, query, user_config.beta_id3)
+        monster, mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link = await perform_mats_query(dgcog, query, user_config.beta_id3)
 
-        return EvosViewState(original_author_id, menu_type, raw_query, query, user_config.color, monster,
-                   alt_versions, gem_versions, extra_state=ims)
+        return MaterialsViewState(original_author_id, menu_type, raw_query, query, user_config.color, monster,
+                                  mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link, extra_state=ims)

--- a/padinfo/view_state/otherinfo.py
+++ b/padinfo/view_state/otherinfo.py
@@ -1,0 +1,40 @@
+from typing import TYPE_CHECKING
+
+from padinfo.common.config import UserConfig
+from padinfo.core.id import perform_otherinfo_query
+from padinfo.view_state.base import ViewState
+
+if TYPE_CHECKING:
+    from dadguide.models.monster_model import MonsterModel
+
+
+class OtherInfoViewState(ViewState):
+    def __init__(self, original_author_id, menu_type, raw_query, query, color, monster: "MonsterModel",
+                 extra_state=None):
+        super().__init__(original_author_id, menu_type, raw_query, extra_state=extra_state)
+        self.color = color
+        self.monster = monster
+        self.query = query
+
+    def serialize(self):
+        ret = super().serialize()
+        ret.update({
+            'query': self.query,
+            'resolved_monster_id': self.monster.monster_id,
+        })
+        return ret
+
+    @staticmethod
+    async def deserialize(dgcog, user_config: UserConfig, ims: dict):
+        raw_query = ims['raw_query']
+
+        # This is to support the 2 vs 1 monster query difference between ^ls and ^id
+        query = ims.get('query') or raw_query
+
+        original_author_id = ims['original_author_id']
+        menu_type = ims['menu_type']
+
+        monster = await perform_otherinfo_query(dgcog, query, user_config.beta_id3)
+
+        return OtherInfoViewState(original_author_id, menu_type, raw_query, query, user_config.color, monster,
+                                  extra_state=ims)

--- a/padinfo/view_state/pantheon.py
+++ b/padinfo/view_state/pantheon.py
@@ -1,0 +1,44 @@
+from typing import TYPE_CHECKING, List
+
+from padinfo.common.config import UserConfig
+from padinfo.core.id import perform_pantheon_query
+from padinfo.view_state.base import ViewState
+
+if TYPE_CHECKING:
+    from dadguide.models.monster_model import MonsterModel
+
+
+class PantheonViewState(ViewState):
+    def __init__(self, original_author_id, menu_type, raw_query, query, color, monster: "MonsterModel",
+                 pantheon_list: List["MonsterModel"], series_name: str,
+                 extra_state=None):
+        super().__init__(original_author_id, menu_type, raw_query, extra_state=extra_state)
+        self.series_name = series_name
+        self.pantheon_list = pantheon_list
+        self.color = color
+        self.monster = monster
+        self.query = query
+
+    def serialize(self):
+        ret = super().serialize()
+        ret.update({
+            'query': self.query,
+            'resolved_monster_id': self.monster.monster_id,
+        })
+        return ret
+
+    @staticmethod
+    async def deserialize(dgcog, user_config: UserConfig, ims: dict):
+        raw_query = ims['raw_query']
+
+        # This is to support the 2 vs 1 monster query difference between ^ls and ^id
+        query = ims.get('query') or raw_query
+
+        original_author_id = ims['original_author_id']
+        menu_type = ims['menu_type']
+
+        monster, pantheon_list, series_name = await perform_pantheon_query(dgcog, query, user_config.beta_id3)
+
+        return PantheonViewState(original_author_id, menu_type, raw_query, query, user_config.color, monster,
+                            pantheon_list, series_name,
+                            extra_state=ims)

--- a/padinfo/view_state/pic.py
+++ b/padinfo/view_state/pic.py
@@ -1,0 +1,40 @@
+from typing import TYPE_CHECKING
+
+from padinfo.common.config import UserConfig
+from padinfo.core.id import perform_pic_query
+from padinfo.view_state.base import ViewState
+
+if TYPE_CHECKING:
+    from dadguide.models.monster_model import MonsterModel
+
+
+class PicViewState(ViewState):
+    def __init__(self, original_author_id, menu_type, raw_query, query, color, monster: "MonsterModel",
+                 extra_state=None):
+        super().__init__(original_author_id, menu_type, raw_query, extra_state=extra_state)
+        self.color = color
+        self.monster = monster
+        self.query = query
+
+    def serialize(self):
+        ret = super().serialize()
+        ret.update({
+            'query': self.query,
+            'resolved_monster_id': self.monster.monster_id,
+        })
+        return ret
+
+    @staticmethod
+    async def deserialize(dgcog, user_config: UserConfig, ims: dict):
+        raw_query = ims['raw_query']
+
+        # This is to support the 2 vs 1 monster query difference between ^ls and ^id
+        query = ims.get('query') or raw_query
+
+        original_author_id = ims['original_author_id']
+        menu_type = ims['menu_type']
+
+        monster = await perform_pic_query(dgcog, query, user_config.beta_id3)
+
+        return PicViewState(original_author_id, menu_type, raw_query, query, user_config.color, monster,
+                            extra_state=ims)


### PR DESCRIPTION
* Renamed `id_menu.py` to `id_menu_old.py`
* Created new `id_menu.py` field
* Enabled new IdMenu menu type to be listened to in `padinfo.test_reaction_add` listener
* For evos, materials, pantheons, pic, otherinfo:
    * Created ViewState
    * Updated View.embed to use ViewState as only parameter
    * Updated the command in in id_menu_old to construct a ViewState holding all parameters
* Added some test code to padinfo._id method; it's currently commented out as arrows aren't implemented

## Outstanding issues
* Still need to implement arrows
    * Do we need ViewState.VIEW_TYPE ? Remember a different type of view state is needed depending on current view state.
* We need to be able to hide individual tabs - https://github.com/TsubakiBotPad/discord-menu/issues/22
* Figure out how the entry points all work, especially with IdMenu.INITIAL_EMOJI - this isn't analogous to how LS works