### PR TITLE
Fix return type for name token processor

### DIFF
--- a/padinfo/core/find_monster.py
+++ b/padinfo/core/find_monster.py
@@ -169,8 +169,6 @@ class FindMonster:
         ms = sorted([nt for nt in index2.all_name_tokens if calc_ratio_name(t, nt, index2) > self.TOKEN_JW_DISTANCE],
                     key=lambda nt: calc_ratio_name(t, nt, index2), reverse=True)
         ms += [token for token in index2.all_name_tokens if token.startswith(t)]
-        if not ms:
-            return None
         for match in ms:
             score = calc_ratio_name(t, match, index2)
             for m in index2.manual[match]:


### PR DESCRIPTION
This makes `get_valid_monsters_from_name_token` always return an iterable because it will throw an error when it returns None.  This fixes long random keysmashes raising an error when searched via id3