### PR TITLE
Return None in transition func when pane is unsupported

### DIFF
--- a/padinfo/core/find_monster.py
+++ b/padinfo/core/find_monster.py
@@ -329,7 +329,7 @@ async def find_monster_search(tokenized_query, dgcog) -> \
         if t not in dgcog.index2.all_modifiers:
             settings.add_typo_mod(t)
 
-    print(mod_tokens, neg_mod_tokens, name_query_tokens, neg_name_tokens)
+    # print(mod_tokens, neg_mod_tokens, name_query_tokens, neg_name_tokens)
     matches = defaultdict(MonsterMatch)
 
     if name_query_tokens:
@@ -353,8 +353,8 @@ async def find_monster_search(tokenized_query, dgcog) -> \
         # no modifiers match any monster in the evo tree
         return None, {}
 
-    print({k: v for k, v in sorted(matches.items(), key=lambda kv: kv[1].score, reverse=True)
-           if k in monster_gen})
+    # print({k: v for k, v in sorted(matches.items(), key=lambda kv: kv[1].score, reverse=True)
+    #        if k in monster_gen})
 
     # Return most likely candidate based on query.
     mon = find_monster.get_most_eligable_monster(monster_gen, dgcog, tokenized_query, matches)

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -163,14 +163,18 @@ class IdMenu:
         )
 
     @staticmethod
-    def evos_control(state: EvosViewState):
+    def evos_control(state: Optional[EvosViewState]):
+        if state is None:
+            return None
         return EmbedControl(
             [EvosView.embed(state)],
             [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
         )
 
     @staticmethod
-    def mats_control(state: MaterialsViewState):
+    def mats_control(state: Optional[MaterialsViewState]):
+        if state is None:
+            return None
         return EmbedControl(
             [MaterialsView.embed(state)],
             [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
@@ -184,7 +188,9 @@ class IdMenu:
         )
 
     @staticmethod
-    def pantheon_control(state: PantheonViewState):
+    def pantheon_control(state: Optional[PantheonViewState]):
+        if state is None:
+            return None
         return EmbedControl(
             [PantheonView.embed(state)],
             [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]

--- a/padinfo/info.json
+++ b/padinfo/info.json
@@ -23,7 +23,7 @@
     "tsutils>=3.1.0",
     "prettytable",
     "python-levenshtein",
-    "discord-menu>=0.12.0"
+    "discord-menu>=0.13.0"
   ],
   "tags": [
     "PAD"

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -351,6 +351,11 @@ class PadInfo(commands.Cog, IdTest):
 
         alt_versions, gem_versions = await EvosViewState.query(dgcog, monster)
 
+        if alt_versions is None:
+            await ctx.send('Your query `{}` found [{}] {}, '.format(query, monster.monster_id,
+                                                                    monster.name_en) + 'which has no alt evos or gems.')
+            return
+
         state = EvosViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
                               monster, alt_versions, gem_versions,
                               use_evo_scroll=settings.checkEvoID(ctx.author.id))

--- a/padinfo/view_state/evos.py
+++ b/padinfo/view_state/evos.py
@@ -5,6 +5,8 @@ from padinfo.pane_names import IdMenuPaneNames
 from padinfo.view_state.base import ViewState
 from padinfo.view_state.common import get_monster_from_ims
 
+from discordmenu.errors import UnsupportedPaneType
+
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
@@ -37,6 +39,9 @@ class EvosViewState(ViewState):
         monster = await get_monster_from_ims(dgcog, user_config, ims)
         alt_versions, gem_versions = await EvosViewState.query(dgcog, monster)
 
+        if alt_versions is None:
+            raise UnsupportedPaneType
+
         raw_query = ims['raw_query']
         query = ims.get('query') or raw_query
         original_author_id = ims['original_author_id']
@@ -54,4 +59,6 @@ class EvosViewState(ViewState):
         alt_versions = sorted({*db_context.graph.get_alt_monsters_by_id(monster.monster_no)},
                               key=lambda x: x.monster_id)
         gem_versions = list(filter(None, map(db_context.graph.evo_gem_monster, alt_versions)))
+        if len(alt_versions) == 1 and len(gem_versions) == 0:
+            return None, None
         return alt_versions, gem_versions

--- a/padinfo/view_state/evos.py
+++ b/padinfo/view_state/evos.py
@@ -5,8 +5,6 @@ from padinfo.pane_names import IdMenuPaneNames
 from padinfo.view_state.base import ViewState
 from padinfo.view_state.common import get_monster_from_ims
 
-from discordmenu.errors import UnsupportedPaneType
-
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
@@ -40,7 +38,8 @@ class EvosViewState(ViewState):
         alt_versions, gem_versions = await EvosViewState.query(dgcog, monster)
 
         if alt_versions is None:
-            raise UnsupportedPaneType
+            return None
+        print('def not kittens')
 
         raw_query = ims['raw_query']
         query = ims.get('query') or raw_query

--- a/padinfo/view_state/materials.py
+++ b/padinfo/view_state/materials.py
@@ -6,8 +6,6 @@ from padinfo.pane_names import IdMenuPaneNames
 from padinfo.view_state.base import ViewState
 from padinfo.view_state.common import get_monster_from_ims
 
-from discordmenu.errors import UnsupportedPaneType
-
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
@@ -49,7 +47,7 @@ class MaterialsViewState(ViewState):
             await MaterialsViewState.query(dgcog, monster)
 
         if mats is None:
-            raise UnsupportedPaneType
+            return None
 
         raw_query = ims['raw_query']
         query = ims.get('query') or raw_query

--- a/padinfo/view_state/materials.py
+++ b/padinfo/view_state/materials.py
@@ -6,6 +6,8 @@ from padinfo.pane_names import IdMenuPaneNames
 from padinfo.view_state.base import ViewState
 from padinfo.view_state.common import get_monster_from_ims
 
+from discordmenu.errors import UnsupportedPaneType
+
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
@@ -45,6 +47,9 @@ class MaterialsViewState(ViewState):
         monster = await get_monster_from_ims(dgcog, user_config, ims)
         mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link = \
             await MaterialsViewState.query(dgcog, monster)
+
+        if mats is None:
+            raise UnsupportedPaneType
 
         raw_query = ims['raw_query']
         query = ims.get('query') or raw_query

--- a/padinfo/view_state/pantheon.py
+++ b/padinfo/view_state/pantheon.py
@@ -5,6 +5,8 @@ from padinfo.pane_names import IdMenuPaneNames
 from padinfo.view_state.base import ViewState
 from padinfo.view_state.common import get_monster_from_ims
 
+from discordmenu.errors import UnsupportedPaneType
+
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
@@ -36,6 +38,9 @@ class PantheonViewState(ViewState):
     async def deserialize(dgcog, user_config: UserConfig, ims: dict):
         monster = await get_monster_from_ims(dgcog, user_config, ims)
         pantheon_list, series_name = await PantheonViewState.query(dgcog, monster)
+
+        if pantheon_list is None:
+            raise UnsupportedPaneType
 
         raw_query = ims['raw_query']
         query = ims.get('query') or raw_query

--- a/padinfo/view_state/pantheon.py
+++ b/padinfo/view_state/pantheon.py
@@ -5,8 +5,6 @@ from padinfo.pane_names import IdMenuPaneNames
 from padinfo.view_state.base import ViewState
 from padinfo.view_state.common import get_monster_from_ims
 
-from discordmenu.errors import UnsupportedPaneType
-
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
@@ -40,7 +38,7 @@ class PantheonViewState(ViewState):
         pantheon_list, series_name = await PantheonViewState.query(dgcog, monster)
 
         if pantheon_list is None:
-            raise UnsupportedPaneType
+            return None
 
         raw_query = ims['raw_query']
         query = ims.get('query') or raw_query


### PR DESCRIPTION
Per https://github.com/TsubakiBotPad/discord-menu/pull/24 this gives the user some feedback when they try to do a disallowed action in the id menu, showing a no-entry sign for 3 seconds as well as removing the emoji.

I also now make evo screen unavailable in `^id` when there's no interesting information there. (Thanks Turtle for the fantastic failure message text, I totally stole it)