### PR TITLE
Update transforminfo

### DIFF
--- a/padinfo/tf_menu.py
+++ b/padinfo/tf_menu.py
@@ -15,9 +15,10 @@ from padinfo.view_state.transforminfo import TransformInfoViewState
 if TYPE_CHECKING:
     pass
 
-emoji_button_names = ['\N{HOUSE BUILDING}', '\N{DOWNWARDS BLACK ARROW}', '\N{UPWARDS BLACK ARROW}',
-                      '\N{CROSS MARK}']
+emoji_button_names = ['\N{HOUSE BUILDING}', '\N{DOWN-POINTING RED TRIANGLE}',
+                      '\N{BLACK RIGHT-POINTING TRIANGLE}', '\N{CROSS MARK}']
 menu_emoji_config = EmbedMenuEmojiConfig(delete_message='\N{CROSS MARK}')
+
 
 class TransformInfoMenu:
     INITIAL_EMOJI = emoji_button_names[0]

--- a/padinfo/view/id.py
+++ b/padinfo/view/id.py
@@ -74,10 +74,11 @@ class IdView:
         killers = m.killers if m==transform_base else transform_base.killers
         killers_text = 'Any' if 'Any' in killers else \
             ' '.join(_killer_latent_emoji(k) for k in killers)
-        available_killer_text = 'Available killers:' if m==transform_base else 'Avail. killers (pre-xform):'
         return Box(
-            BoldText(available_killer_text),
-            Text('[{} slots]'.format(m.latent_slots)),
+            BoldText('Available killers:'),
+            Text('\N{DOWN-POINTING RED TRIANGLE}' if m!=transform_base else ''),
+            Text('[{} slots]'.format(m.latent_slots if m==transform_base \
+                else transform_base.latent_slots)),
             Text(killers_text),
             delimiter=' '
         )

--- a/padinfo/view/id.py
+++ b/padinfo/view/id.py
@@ -71,8 +71,9 @@ class IdView:
 
     @staticmethod
     def killers_row(m: "MonsterModel", transform_base):
-        killers_text = 'Any' if 'Any' in m.killers else \
-            ' '.join(_killer_latent_emoji(k) for k in transform_base.killers)
+        killers = m.killers if m==transform_base else transform_base.killers
+        killers_text = 'Any' if 'Any' in killers else \
+            ' '.join(_killer_latent_emoji(k) for k in killers)
         available_killer_text = 'Available killers:' if m==transform_base else 'Avail. killers (pre-xform):'
         return Box(
             BoldText(available_killer_text),

--- a/padinfo/view/transforminfo.py
+++ b/padinfo/view/transforminfo.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 BASE_EMOJI = '\N{DOWN-POINTING RED TRIANGLE}'
 
 
-def _get_base_info(m: "MonsterModel"):
+def base_info(m: "MonsterModel"):
     return Box(
         Box(
             BASE_EMOJI,
@@ -59,7 +59,7 @@ class TransformInfoView:
                 Box(
                     IdView.normal_awakenings_row(transformed_mon)
                         if len(transformed_mon.awakenings) != 0 else Box(Text('No Awakenings')),
-                    _get_base_info(base_mon),
+                    base_info(base_mon),
                     IdView.killers_row(transformed_mon, base_mon)
                 ),
             ),

--- a/padinfo/view/transforminfo.py
+++ b/padinfo/view/transforminfo.py
@@ -17,23 +17,33 @@ from padinfo.view_state.transforminfo import TransformInfoViewState
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
+BASE_EMOJI = '\N{DOWN-POINTING RED TRIANGLE}'
 
-def base_info(m: "MonsterModel"):
+
+def _get_base_info(m: "MonsterModel"):
     return Box(
         Box(
-            '\N{DOWN-POINTING RED TRIANGLE}',
+            BASE_EMOJI,
             IdView.normal_awakenings_row(m) if len(m.awakenings) != 0
                 else Box(Text('No Awakenings')),
             delimiter=' '
         ),
-        IdView.super_awakenings_row(m),
-        # the transform base of the base is the same
-        IdView.killers_row(m, m)
+        IdView.super_awakenings_row(m)
+    )
+
+def transform_skill_header(m: "MonsterModel"):
+    active_skill = m.active_skill
+    active_cd = '({} cd)'.format(active_skill.turn_min) if active_skill else 'None'
+    return Box(
+        BoldText('Active Skill'),
+        BoldText(active_cd),
+        delimiter=' '
     )
 
 def base_skill(m: "MonsterModel"):
     active_skill = m.active_skill
-    return (" (Base: {} -> {})".format(active_skill.turn_max, active_skill.turn_min) if active_skill
+    return (" (" + BASE_EMOJI + " "
+            + "{} -> {})".format(active_skill.turn_max, active_skill.turn_min) if active_skill
         else 'None')
 
 
@@ -49,7 +59,8 @@ class TransformInfoView:
                 Box(
                     IdView.normal_awakenings_row(transformed_mon)
                         if len(transformed_mon.awakenings) != 0 else Box(Text('No Awakenings')),
-                    base_info(base_mon)
+                    _get_base_info(base_mon),
+                    IdView.killers_row(transformed_mon, base_mon)
                 ),
             ),
             EmbedField(
@@ -64,7 +75,7 @@ class TransformInfoView:
                 inline=True
             ),
             EmbedField(
-                IdView.active_skill_header(transformed_mon).to_markdown() + base_skill(base_mon),
+                transform_skill_header(transformed_mon).to_markdown() + base_skill(base_mon),
                 Text(transformed_mon.active_skill.desc if transformed_mon.active_skill else 'None')
             ),
             EmbedField(


### PR DESCRIPTION
This makes some updates to `[p]transforminfo`, mostly in response to River's feedback.

Changes included:
- There was a bug in id where cards that gained balance type upon transformation showed their post-transform "Any" killers despite being labeled as "pre-transform".
- The downward triangle emoji is now peppered more throughout the transforminfo view.
- Transform skills now simply show as `(# cd)`.
- The emoji reactions for base and transform were changed. Hopefully for the better, but we'll see.