### PR TITLE
Add MonsterList linked menus for evolist & idsearch

### DIFF
--- a/padinfo/MonsterListMenu.py
+++ b/padinfo/MonsterListMenu.py
@@ -24,6 +24,7 @@ menu_emoji_config = EmbedMenuEmojiConfig(delete_message='\N{CROSS MARK}')
 
 class MonsterListMenu:
     MENU_TYPE = 'MonsterListMenu'
+    CHILD_MENU_TYPE = 'IdMenu'
 
     @staticmethod
     def menu(original_author_id, friend_ids, bot_id, initial_control=None):

--- a/padinfo/MonsterListMenu.py
+++ b/padinfo/MonsterListMenu.py
@@ -9,7 +9,7 @@ from discordmenu.reaction_filter import ValidEmojiReactionFilter, NotPosterEmoji
 from tsutils import char_to_emoji
 
 from padinfo.id_menu import IdMenu
-from padinfo.pane_names import IdMenuPaneNames, MonsterListPaneNames
+from padinfo.pane_names import IdMenuPaneNames, MonsterListPaneNames, global_emoji_responses
 from padinfo.reaction_list import get_id_menu_initial_reaction_list
 from padinfo.view.id import IdView
 from padinfo.view.monster_list import MonsterListView
@@ -45,6 +45,11 @@ class MonsterListMenu:
         # this is only called once on message load
         if data.get('child_message_id'):
             ims['child_message_id'] = data['child_message_id']
+        return await MonsterListMenu.respond_with_monster_list(message, ims, **data)
+
+    @staticmethod
+    async def respond_with_reset(message: Optional[Message], ims, **data):
+        # replace with the overview list after the child menu changes
         return await MonsterListMenu.respond_with_monster_list(message, ims, **data)
 
     @staticmethod
@@ -84,7 +89,7 @@ class MonsterListMenu:
     @staticmethod
     async def respond_with_delete(message: Optional[Message], ims, **data):
         # this function is needed because we want different deletion behavior in the CHILD menu
-        return await message.delete()
+        await message.delete()
 
     @staticmethod
     async def respond_with_0(message: Optional[Message], ims, **data):
@@ -172,10 +177,12 @@ class MonsterListMenuPanes:
         MonsterListMenu.respond_with_10: ('\N{KEYCAP TEN}', IdMenuPaneNames.id),
         MonsterListMenu.respond_with_eyes: ('\N{EYES}', None),
         MonsterListMenu.respond_with_refresh: (
-            '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}', IdMenuPaneNames.refresh),
+            '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}', MonsterListPaneNames.refresh),
+        MonsterListMenu.respond_with_reset: (global_emoji_responses['reset'], MonsterListPaneNames.reset)
     }
     HIDDEN_EMOJIS = [
         MonsterListPaneNames.refresh,
+        MonsterListPaneNames.reset,
     ]
 
     @classmethod

--- a/padinfo/MonsterListMenu.py
+++ b/padinfo/MonsterListMenu.py
@@ -137,7 +137,6 @@ class MonsterListMenu:
         reaction_list = state.reaction_list
         if '\N{EYES}' in reaction_list:
             reaction_list.pop('\N{EYES}')
-        print(reaction_list)
         return EmbedControl(
             [MonsterListView.embed(state)],
             reaction_list

--- a/padinfo/MonsterListMenu.py
+++ b/padinfo/MonsterListMenu.py
@@ -72,10 +72,14 @@ class MonsterListMenu:
         dgcog = data['dgcog']
         reaction_list = await get_id_menu_initial_reaction_list(None, dgcog, dgcog.database.graph.get_monster(
             int(ims['resolved_monster_id'])), force_evoscroll=True)
-        ims['reaction_list'] = ','.join(reaction_list)
-        if data.get('child_message_ims') is None:
+        if not data.get('child_message_ims'):
+            # default to the overview screen if we weren't already on a screen
+            ims['reaction_list'] = ','.join(reaction_list)
+
             return await IdMenu.respond_with_current_id(message, ims, **data)
-        return await IdMenu.respond_with_refresh(message, ims, **data)
+        data['child_message_ims']['reaction_list'] = ','.join(reaction_list)
+        data['child_message_ims']['resolved_monster_id'] = int(ims['resolved_monster_id'])
+        return await IdMenu.respond_with_refresh(message, data['child_message_ims'], **data)
 
     @staticmethod
     async def respond_with_0(message: Optional[Message], ims, **data):

--- a/padinfo/MonsterListMenu.py
+++ b/padinfo/MonsterListMenu.py
@@ -19,7 +19,7 @@ from padinfo.view_state.monster_list import MonsterListViewState
 if TYPE_CHECKING:
     pass
 
-menu_emoji_config = EmbedMenuEmojiConfig()
+menu_emoji_config = EmbedMenuEmojiConfig(delete_message='\N{CROSS MARK}')
 
 
 class MonsterListMenu:
@@ -37,7 +37,7 @@ class MonsterListMenu:
             BotAuthoredMessageReactionFilter(bot_id),
             MessageOwnerReactionFilter(original_author_id, FriendReactionFilter(original_author_id, friend_ids))
         ]
-        embed = EmbedMenu(reaction_filters, MonsterListMenuPanes.transitions(), initial_control, menu_emoji_config)
+        embed = EmbedMenu(reaction_filters, MonsterListMenuPanes.transitions(), initial_control, menu_emoji_config, delete_func=MonsterListMenu.respond_with_delete)
         return embed
 
     @staticmethod
@@ -84,7 +84,7 @@ class MonsterListMenu:
     @staticmethod
     async def respond_with_delete(message: Optional[Message], ims, **data):
         # this function is needed because we want different deletion behavior in the CHILD menu
-        await message.delete()
+        return await message.delete()
 
     @staticmethod
     async def respond_with_0(message: Optional[Message], ims, **data):
@@ -170,7 +170,6 @@ class MonsterListMenuPanes:
         MonsterListMenu.respond_with_8: (char_to_emoji('8'), IdMenuPaneNames.id),
         MonsterListMenu.respond_with_9: (char_to_emoji('9'), IdMenuPaneNames.id),
         MonsterListMenu.respond_with_10: ('\N{KEYCAP TEN}', IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_delete: ('\N{CROSS MARK}', None),
         MonsterListMenu.respond_with_eyes: ('\N{EYES}', None),
         MonsterListMenu.respond_with_refresh: (
             '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}', IdMenuPaneNames.refresh),
@@ -193,7 +192,7 @@ class MonsterListMenuPanes:
 
     @staticmethod
     def get_initial_reaction_list(number_of_evos: int):
-        return MonsterListMenuPanes.emoji_names()[:number_of_evos + 1] + ['\N{CROSS MARK}']
+        return MonsterListMenuPanes.emoji_names()[:number_of_evos + 1]
 
     @staticmethod
     def emoji_name_to_emoji(name: str):

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -118,7 +118,7 @@ class IdMenu:
     async def respond_with_delete(message: Optional[Message], ims, **data):
         # This function is designed to be used only when IdMenu is a child menu, otherwise we'd just use
         # the built-in deletion function
-        return await message.edit(embed=None)
+        await message.edit(embed=None)
 
     @staticmethod
     async def respond_with_current_id(message: Optional[Message], ims, **data):

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -241,7 +241,7 @@ class IdMenuPanes:
         IdMenu.respond_with_left: ('\N{BLACK LEFT-POINTING TRIANGLE}', None),
         IdMenu.respond_with_right: ('\N{BLACK RIGHT-POINTING TRIANGLE}', None),
         IdMenu.respond_with_current_id: ('\N{HOUSE BUILDING}', IdMenuPaneNames.id),
-        IdMenu.respond_with_evos: (char_to_emoji('z'), IdMenuPaneNames.evos),
+        IdMenu.respond_with_evos: (char_to_emoji('E'), IdMenuPaneNames.evos),
         IdMenu.respond_with_mats: ('\N{MEAT ON BONE}', IdMenuPaneNames.materials),
         IdMenu.respond_with_picture: ('\N{FRAME WITH PICTURE}', IdMenuPaneNames.pic),
         IdMenu.respond_with_pantheon: ('\N{CLASSICAL BUILDING}', IdMenuPaneNames.pantheon),

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -115,14 +115,15 @@ class IdMenu:
         return await response_func(message, ims, **data)
 
     @staticmethod
+    async def respond_with_delete(message: Optional[Message], ims, **data):
+        # This function is designed to be used only when IdMenu is a child menu, otherwise we'd just use
+        # the built-in deletion function
+        return await message.edit(embed=None)
+
+    @staticmethod
     async def respond_with_current_id(message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
         user_config = data['user_config']
-
-        print('???????????')
-        for r in ims['reaction_list'].split(','):
-            print(str(r))
-        print('???????????')
 
         view_state = await IdViewState.deserialize(dgcog, user_config, ims)
         control = IdMenu.id_control(view_state)
@@ -178,7 +179,6 @@ class IdMenu:
         if state is None:
             return None
         reaction_list = state.reaction_list
-        print(reaction_list)
         return EmbedControl(
             [IdView.embed(state)],
             reaction_list or [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
@@ -247,10 +247,12 @@ class IdMenuPanes:
         IdMenu.respond_with_pantheon: ('\N{CLASSICAL BUILDING}', IdMenuPaneNames.pantheon),
         IdMenu.respond_with_otherinfo: ('\N{SCROLL}', IdMenuPaneNames.otherinfo),
         IdMenu.respond_with_refresh: (
-            '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}', IdMenuPaneNames.refresh)
+            '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}', IdMenuPaneNames.refresh),
+        IdMenu.respond_with_delete: ('\N{CROSS MARK}', IdMenuPaneNames.delete),
     }
     HIDDEN_EMOJIS = [
         IdMenuPaneNames.refresh,
+        IdMenuPaneNames.delete,
     ]
 
     @classmethod

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -117,8 +117,6 @@ class IdMenu:
 
     @staticmethod
     async def respond_with_delete(message: Optional[Message], ims, **data):
-        # This function is designed to be used only when IdMenu is a child menu, otherwise we'd just use
-        # the built-in deletion function
         if ims.get('is_child'):
             return await message.edit(embed=None)
         return await message.delete()

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -44,7 +44,8 @@ class IdMenu:
             BotAuthoredMessageReactionFilter(bot_id),
             MessageOwnerReactionFilter(original_author_id, FriendReactionFilter(original_author_id, friend_ids))
         ]
-        embed = EmbedMenu(reaction_filters, IdMenuPanes.transitions(), initial_control, menu_emoji_config)
+        embed = EmbedMenu(reaction_filters, IdMenuPanes.transitions(), initial_control, menu_emoji_config,
+                          delete_func=IdMenu.respond_with_delete)
         return embed
 
     @staticmethod
@@ -118,7 +119,9 @@ class IdMenu:
     async def respond_with_delete(message: Optional[Message], ims, **data):
         # This function is designed to be used only when IdMenu is a child menu, otherwise we'd just use
         # the built-in deletion function
-        await message.edit(embed=None)
+        if ims.get('is_child'):
+            return await message.edit(embed=None)
+        return await message.delete()
 
     @staticmethod
     async def respond_with_current_id(message: Optional[Message], ims, **data):

--- a/padinfo/id_menu.py
+++ b/padinfo/id_menu.py
@@ -119,6 +119,11 @@ class IdMenu:
         dgcog = data['dgcog']
         user_config = data['user_config']
 
+        print('???????????')
+        for r in ims['reaction_list'].split(','):
+            print(str(r))
+        print('???????????')
+
         view_state = await IdViewState.deserialize(dgcog, user_config, ims)
         control = IdMenu.id_control(view_state)
         return control
@@ -173,6 +178,7 @@ class IdMenu:
         if state is None:
             return None
         reaction_list = state.reaction_list
+        print(reaction_list)
         return EmbedControl(
             [IdView.embed(state)],
             reaction_list or [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
@@ -235,7 +241,7 @@ class IdMenuPanes:
         IdMenu.respond_with_left: ('\N{BLACK LEFT-POINTING TRIANGLE}', None),
         IdMenu.respond_with_right: ('\N{BLACK RIGHT-POINTING TRIANGLE}', None),
         IdMenu.respond_with_current_id: ('\N{HOUSE BUILDING}', IdMenuPaneNames.id),
-        IdMenu.respond_with_evos: (char_to_emoji('e'), IdMenuPaneNames.evos),
+        IdMenu.respond_with_evos: (char_to_emoji('z'), IdMenuPaneNames.evos),
         IdMenu.respond_with_mats: ('\N{MEAT ON BONE}', IdMenuPaneNames.materials),
         IdMenu.respond_with_picture: ('\N{FRAME WITH PICTURE}', IdMenuPaneNames.pic),
         IdMenu.respond_with_pantheon: ('\N{CLASSICAL BUILDING}', IdMenuPaneNames.pantheon),

--- a/padinfo/info.json
+++ b/padinfo/info.json
@@ -23,7 +23,7 @@
     "tsutils>=3.1.0",
     "prettytable",
     "python-levenshtein",
-    "discord-menu>=0.13.0"
+    "discord-menu>=0.14.0"
   ],
   "tags": [
     "PAD"

--- a/padinfo/monster_list_menu.py
+++ b/padinfo/monster_list_menu.py
@@ -129,23 +129,24 @@ class MonsterListMenu:
 class MonsterListMenuPanes:
     INITIAL_EMOJI = '\N{HOUSE BUILDING}'
     DATA = {
-        MonsterListMenu.respond_with_monster_list: ('\N{HOUSE BUILDING}', IdMenuPaneNames.evos),
-        MonsterListMenu.respond_with_0: (char_to_emoji('0'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_1: (char_to_emoji('1'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_2: (char_to_emoji('2'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_3: (char_to_emoji('3'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_4: (char_to_emoji('4'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_5: (char_to_emoji('5'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_6: (char_to_emoji('6'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_7: (char_to_emoji('7'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_8: (char_to_emoji('8'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_9: (char_to_emoji('9'), IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_10: ('\N{KEYCAP TEN}', IdMenuPaneNames.id),
+        MonsterListMenu.respond_with_monster_list: ('\N{HOUSE BUILDING}', MonsterListPaneNames.home),
+        MonsterListMenu.respond_with_0: (char_to_emoji('0'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_1: (char_to_emoji('1'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_2: (char_to_emoji('2'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_3: (char_to_emoji('3'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_4: (char_to_emoji('4'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_5: (char_to_emoji('5'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_6: (char_to_emoji('6'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_7: (char_to_emoji('7'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_8: (char_to_emoji('8'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_9: (char_to_emoji('9'), MonsterListPaneNames.id),
+        MonsterListMenu.respond_with_10: ('\N{KEYCAP TEN}', MonsterListPaneNames.id),
         MonsterListMenu.respond_with_refresh: (
             '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}', MonsterListPaneNames.refresh),
         MonsterListMenu.respond_with_reset: (global_emoji_responses['reset'], MonsterListPaneNames.reset)
     }
     HIDDEN_EMOJIS = [
+        MonsterListPaneNames.home,
         MonsterListPaneNames.refresh,
         MonsterListPaneNames.reset,
     ]

--- a/padinfo/monster_list_menu.py
+++ b/padinfo/monster_list_menu.py
@@ -8,12 +8,9 @@ from discordmenu.reaction_filter import ValidEmojiReactionFilter, NotPosterEmoji
     MessageOwnerReactionFilter, FriendReactionFilter, BotAuthoredMessageReactionFilter
 from tsutils import char_to_emoji
 
-from padinfo.id_menu import IdMenu
+from padinfo.id_menu import IdMenu, IdMenuPanes
 from padinfo.pane_names import IdMenuPaneNames, MonsterListPaneNames, global_emoji_responses
-from padinfo.reaction_list import get_id_menu_initial_reaction_list
-from padinfo.view.id import IdView
 from padinfo.view.monster_list import MonsterListView
-from padinfo.view_state.id import IdViewState
 from padinfo.view_state.monster_list import MonsterListViewState
 
 if TYPE_CHECKING:
@@ -63,21 +60,8 @@ class MonsterListMenu:
 
     @staticmethod
     async def respond_with_n(message: Optional[Message], ims, n, **data):
-        dgcog = data['dgcog']
-        user_config = data['user_config']
         ims['resolved_monster_id'] = int(ims['monster_list'][n])
-
-        view_state = await IdViewState.deserialize(dgcog, user_config, ims)
-        control = MonsterListMenu.id_control(view_state)
-        return control
-
-    @staticmethod
-    async def respond_with_eyes(message: Optional[Message], ims, **data):
-        # the message we get here is the NEXT message, not the current one. The ims and everything else
-        # is for the current message, but they should be identical.
-        dgcog = data['dgcog']
-        reaction_list = await get_id_menu_initial_reaction_list(None, dgcog, dgcog.database.graph.get_monster(
-            int(ims['resolved_monster_id'])), force_evoscroll=True)
+        reaction_list = IdMenuPanes.emoji_names()
         if not data.get('child_message_ims'):
             # default to the overview screen if we weren't already on a screen
             ims['reaction_list'] = ','.join(reaction_list)
@@ -136,22 +120,8 @@ class MonsterListMenu:
         if state is None:
             return None
         reaction_list = state.reaction_list
-        if MonsterListMenuPanes.emoji_name_to_emoji('expand') in reaction_list:
-            reaction_list.pop(MonsterListMenuPanes.emoji_name_to_emoji('expand'))
         return EmbedControl(
             [MonsterListView.embed(state)],
-            reaction_list
-        )
-
-    @staticmethod
-    def id_control(state: IdViewState):
-        if state is None:
-            return None
-        reaction_list = state.reaction_list
-        if MonsterListMenuPanes.emoji_name_to_emoji('expand') not in reaction_list:
-            reaction_list.append(MonsterListMenuPanes.emoji_name_to_emoji('expand'))
-        return EmbedControl(
-            [IdView.embed(state)],
             reaction_list
         )
 
@@ -171,7 +141,6 @@ class MonsterListMenuPanes:
         MonsterListMenu.respond_with_8: (char_to_emoji('8'), IdMenuPaneNames.id),
         MonsterListMenu.respond_with_9: (char_to_emoji('9'), IdMenuPaneNames.id),
         MonsterListMenu.respond_with_10: ('\N{KEYCAP TEN}', IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_eyes: ('\N{SQUARED ID}', MonsterListPaneNames.expand),
         MonsterListMenu.respond_with_refresh: (
             '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}', MonsterListPaneNames.refresh),
         MonsterListMenu.respond_with_reset: (global_emoji_responses['reset'], MonsterListPaneNames.reset)

--- a/padinfo/monster_list_menu.py
+++ b/padinfo/monster_list_menu.py
@@ -141,8 +141,8 @@ class MonsterListMenu:
         if state is None:
             return None
         reaction_list = state.reaction_list
-        if '\N{EYES}' in reaction_list:
-            reaction_list.pop('\N{EYES}')
+        if MonsterListMenuPanes.emoji_name_to_emoji('expand') in reaction_list:
+            reaction_list.pop(MonsterListMenuPanes.emoji_name_to_emoji('expand'))
         return EmbedControl(
             [MonsterListView.embed(state)],
             reaction_list
@@ -153,8 +153,8 @@ class MonsterListMenu:
         if state is None:
             return None
         reaction_list = state.reaction_list
-        if '\N{EYES}' not in reaction_list:
-            reaction_list.append('\N{EYES}')
+        if MonsterListMenuPanes.emoji_name_to_emoji('expand') not in reaction_list:
+            reaction_list.append(MonsterListMenuPanes.emoji_name_to_emoji('expand'))
         return EmbedControl(
             [IdView.embed(state)],
             reaction_list
@@ -176,7 +176,7 @@ class MonsterListMenuPanes:
         MonsterListMenu.respond_with_8: (char_to_emoji('8'), IdMenuPaneNames.id),
         MonsterListMenu.respond_with_9: (char_to_emoji('9'), IdMenuPaneNames.id),
         MonsterListMenu.respond_with_10: ('\N{KEYCAP TEN}', IdMenuPaneNames.id),
-        MonsterListMenu.respond_with_eyes: ('\N{EYES}', None),
+        MonsterListMenu.respond_with_eyes: ('\N{SQUARED ID}', MonsterListPaneNames.expand),
         MonsterListMenu.respond_with_refresh: (
             '\N{ANTICLOCKWISE DOWNWARDS AND UPWARDS OPEN CIRCLE ARROWS}', MonsterListPaneNames.refresh),
         MonsterListMenu.respond_with_reset: (global_emoji_responses['reset'], MonsterListPaneNames.reset)

--- a/padinfo/monster_list_menu.py
+++ b/padinfo/monster_list_menu.py
@@ -38,7 +38,7 @@ class MonsterListMenu:
             BotAuthoredMessageReactionFilter(bot_id),
             MessageOwnerReactionFilter(original_author_id, FriendReactionFilter(original_author_id, friend_ids))
         ]
-        embed = EmbedMenu(reaction_filters, MonsterListMenuPanes.transitions(), initial_control, menu_emoji_config, delete_func=MonsterListMenu.respond_with_delete)
+        embed = EmbedMenu(reaction_filters, MonsterListMenuPanes.transitions(), initial_control, menu_emoji_config)
         return embed
 
     @staticmethod
@@ -86,11 +86,6 @@ class MonsterListMenu:
         data['child_message_ims']['reaction_list'] = ','.join(reaction_list)
         data['child_message_ims']['resolved_monster_id'] = int(ims['resolved_monster_id'])
         return await IdMenu.respond_with_refresh(message, data['child_message_ims'], **data)
-
-    @staticmethod
-    async def respond_with_delete(message: Optional[Message], ims, **data):
-        # this function is needed because we want different deletion behavior in the CHILD menu
-        await message.delete()
 
     @staticmethod
     async def respond_with_0(message: Optional[Message], ims, **data):

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -1126,22 +1126,23 @@ class PadInfo(commands.Cog, IdTest):
         tokenized_query = query.split()
         mw_tokenized_query = find_monster.merge_multi_word_tokens(tokenized_query, dgcog.index2.multi_word_tokens)
 
-        first_monster, matches = max(
+        best_match, matches = max(
             await find_monster_search(tokenized_query, dgcog),
             await find_monster_search(mw_tokenized_query, dgcog)
             if tokenized_query != mw_tokenized_query else (None, {}),
             key=lambda t: t[1][t[0]].score if t[0] else 0
         )
-        if not first_monster:
+        if not best_match:
             await ctx.send("No monster matched.")
             return
 
-        used = []
+        used = [best_match.monster_id]
         monster_list = []
         for m in sorted(matches, key=lambda mon: find_monster.get_priority_tuple(mon, dgcog, matches=matches)):
             bmid = dgcog.database.graph.get_base_monster(m).monster_id
             if bmid not in used:
                 used.append(bmid)
                 monster_list.append(m)
-        monster_list = [first_monster] + monster_list[:10]
+        monster_list.reverse()
+        monster_list = [best_match] + monster_list[:10]
         await self._do_monster_list(ctx, dgcog, query, monster_list, 'ID Search Results')

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -594,7 +594,7 @@ class PadInfo(commands.Cog, IdTest):
                                      )
         evolist_menu = MonsterListMenu.menu(original_author_id, friends, self.bot.user.id)
         message = await evolist_menu.create(ctx, state)
-        child_message = await ctx.send('Child')
+        child_message = await ctx.send('Click \N{EYES} to see a full menu embedded here.')
         ims = state.serialize()
         user_config = await BotConfig.get_user(self.config, ctx.author.id)
         data = {

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -1138,8 +1138,8 @@ class PadInfo(commands.Cog, IdTest):
 
         used = []
         monster_list = []
-        for m in sorted(matches, key=lambda mon: find_monster.get_priority_tuple(mon, matches=matches)):
-            bmid = dgcog.database.graph.get_base_id_by_monster(m)
+        for m in sorted(matches, key=lambda mon: find_monster.get_priority_tuple(mon, dgcog, matches=matches)):
+            bmid = dgcog.database.graph.get_base_monster(m).monster_id
             if bmid not in used:
                 used.append(bmid)
                 monster_list.append(m)

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -169,9 +169,20 @@ class PadInfo(commands.Cog, IdTest):
             MonsterListMenu.MENU_TYPE: MonsterListMenu.menu,
         }
 
-        respond_with_child = [
-            (MonsterListMenu.MENU_TYPE, MonsterListMenuPanes.emoji_name_to_emoji('expand'))
-        ]
+        # If true then the top menu will also respond on reaction
+        respond_with_child = {
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(0)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(1)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(2)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(3)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(4)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(5)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(6)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(7)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(8)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(9)): False,
+            (MonsterListMenu.MENU_TYPE, char_to_emoji(10)): False,
+        }
 
         menu_func = menu_map.get(menu_type)
 
@@ -190,7 +201,7 @@ class PadInfo(commands.Cog, IdTest):
             'dgcog': dgcog,
             'user_config': user_config
         }
-        if ims.get('child_message_id') and (ims['menu_type'], emoji_clicked) in respond_with_child:
+        if ims.get('child_message_id') and (ims['menu_type'], emoji_clicked) in respond_with_child.keys():
             await message.remove_reaction(emoji_clicked, member)
             fctx = await self.bot.get_context(message)
             child_message = await fctx.fetch_message(int(ims['child_message_id']))
@@ -206,7 +217,8 @@ class PadInfo(commands.Cog, IdTest):
             # It's also better from a perceived performance standpoint becuase the emojis are so rate-limited and
             # the reset wouldn't happen until all emojis showed up in the child, so this way it feels like everything
             # happens faster, but regardless the reset must happen first.
-            await embed_menu.transition(message, ims, global_emoji_responses['reset'], member, **data)
+            if respond_with_child[(ims['menu_type'], emoji_clicked)]:
+                await embed_menu.transition(message, ims, global_emoji_responses['reset'], member, **data)
             await embed_menu.transition(child_message, next_child_ims, emoji_clicked, member, **data)
             return
         await embed_menu.transition(message, ims, emoji_clicked, member, **data)
@@ -590,7 +602,7 @@ class PadInfo(commands.Cog, IdTest):
         parent_menu = MonsterListMenu.menu(original_author_id, friends, self.bot.user.id)
         message = await parent_menu.create(ctx, state)
         child_message = await ctx.send(
-            'Click {} to see a full menu embedded here.'.format(MonsterListMenuPanes.emoji_name_to_emoji('expand')))
+            'Click a reaction to see monster details!')
         ims = state.serialize()
         user_config = await BotConfig.get_user(self.config, ctx.author.id)
         data = {

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -192,7 +192,8 @@ class PadInfo(commands.Cog, IdTest):
             fctx = await self.bot.get_context(message)
             child_message = await fctx.fetch_message(int(ims['child_message_id']))
             child_message_ims = child_message.embeds and IntraMessageState.extract_data(child_message.embeds[0])
-            data['child_message_ims'] = child_message_ims
+            if child_message_ims:
+                data['child_message_ims'] = child_message_ims
             ims['menu_type'] = IdMenu.MENU_TYPE
             await embed_menu.transition(child_message, ims, emoji_clicked, member, **data)
             return

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -606,7 +606,7 @@ class PadInfo(commands.Cog, IdTest):
                                      reaction_list=initial_reaction_list
                                      )
         parent_menu = MonsterListMenu.menu(original_author_id, friends, self.bot.user.id)
-        message = await parent_menu.create(ctx, state)
+        message = await ctx.send('Setting up!')
         child_message = await ctx.send(
             'Click a reaction to see monster details!')
         ims = state.serialize()
@@ -618,6 +618,7 @@ class PadInfo(commands.Cog, IdTest):
         }
         try:
             await parent_menu.transition(message, ims, MonsterListMenuPanes.emoji_name_to_emoji('refresh'), ctx.author, **data)
+            await message.edit(content=None)
         except discord.errors.NotFound:
             # The user could delete the menu before we can do this
             pass

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -192,10 +192,11 @@ class PadInfo(commands.Cog, IdTest):
             await message.remove_reaction(emoji_clicked, member)
             fctx = await self.bot.get_context(message)
             child_message = await fctx.fetch_message(int(ims['child_message_id']))
-            child_message_ims = child_message.embeds and IntraMessageState.extract_data(child_message.embeds[0])
-            if child_message_ims:
-                data['child_message_ims'] = child_message_ims
-            ims['menu_type'] = IdMenu.MENU_TYPE
+            previous_child_ims = child_message.embeds and IntraMessageState.extract_data(child_message.embeds[0])
+            if previous_child_ims:
+                data['child_message_ims'] = previous_child_ims
+            next_child_ims = ims.copy()
+            next_child_ims['menu_type'] = IdMenu.MENU_TYPE
 
             # The order here is really important!! The set of emojis attached to the ims is going to be changed in
             # the second transition, so it's VITAL that we reset prior to showing the child menu.
@@ -203,7 +204,7 @@ class PadInfo(commands.Cog, IdTest):
             # the reset wouldn't happen until all emojis showed up in the child, so this way it feels like everything
             # happens faster, but regardless the reset must happen first.
             await embed_menu.transition(message, ims, global_emoji_responses['reset'], member, **data)
-            await embed_menu.transition(child_message, ims, emoji_clicked, member, **data)
+            await embed_menu.transition(child_message, next_child_ims, emoji_clicked, member, **data)
             return
         await embed_menu.transition(message, ims, emoji_clicked, member, **data)
 

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -602,7 +602,10 @@ class PadInfo(commands.Cog, IdTest):
             'user_config': user_config,
             'child_message_id': child_message.id,
         }
-        await evolist_menu.transition(message, ims, MonsterListMenuPanes.emoji_name_to_emoji('refresh'), ctx.author, **data)
+        try:
+            await evolist_menu.transition(message, ims, MonsterListMenuPanes.emoji_name_to_emoji('refresh'), ctx.author, **data)
+        except discord.errors.NotFound:
+            pass
 
     @commands.command(aliases=['leaders', 'leaderskills', 'ls'], usage="<card_1> [card_2]")
     @checks.bot_has_permissions(embed_links=True)

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -199,6 +199,7 @@ class PadInfo(commands.Cog, IdTest):
                 data['child_message_ims'] = previous_child_ims
             next_child_ims = ims.copy()
             next_child_ims['menu_type'] = IdMenu.MENU_TYPE
+            next_child_ims['is_child'] = True
 
             # The order here is really important!! The set of emojis attached to the ims is going to be changed in
             # the second transition, so it's VITAL that we reset prior to showing the child menu.
@@ -572,9 +573,9 @@ class PadInfo(commands.Cog, IdTest):
             await ctx.send('Your query `{}` found [{}] {}, '.format(query, monster.monster_id,
                                                                     monster.name_en) + 'which has no alt evos.')
             return
-        await self._do_monster_list(ctx, dgcog, query, alt_versions)
+        await self._do_monster_list(ctx, dgcog, query, alt_versions, 'Evolution List')
 
-    async def _do_monster_list(self, ctx, dgcog, query, monster_list: List["MonsterModel"]):
+    async def _do_monster_list(self, ctx, dgcog, query, monster_list: List["MonsterModel"], title):
         raw_query = query
         original_author_id = ctx.message.author.id
         friend_cog = self.bot.get_cog("Friend")
@@ -583,7 +584,7 @@ class PadInfo(commands.Cog, IdTest):
         initial_reaction_list = MonsterListMenuPanes.get_initial_reaction_list(len(monster_list))
 
         state = MonsterListViewState(original_author_id, MonsterListMenu.MENU_TYPE, raw_query, query, color,
-                                     monster_list, 'Evolution List',
+                                     monster_list, title,
                                      reaction_list=initial_reaction_list
                                      )
         parent_menu = MonsterListMenu.menu(original_author_id, friends, self.bot.user.id)
@@ -1119,4 +1120,4 @@ class PadInfo(commands.Cog, IdTest):
 
         lower_prio = {m for m in matches if matches[m].score == matches[monster].score}.difference({monster})
         monster_list = [monster] + list(lower_prio)[:10]
-        await self._do_monster_list(ctx, dgcog, query, monster_list)
+        await self._do_monster_list(ctx, dgcog, query, monster_list, 'ID Search Results')

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -18,7 +18,7 @@ from redbot.core.utils.chat_formatting import box, inline, bold, pagify, text_to
 from tabulate import tabulate
 from tsutils import EmojiUpdater, Menu, char_to_emoji, is_donor, rmdiacritics
 
-from padinfo.MonsterListMenu import MonsterListMenu, MonsterListMenuPanes
+from padinfo.monster_list_menu import MonsterListMenu, MonsterListMenuPanes
 from padinfo.common.config import BotConfig
 from padinfo.common.emoji_map import get_attribute_emoji_by_enum, get_awakening_emoji, get_type_emoji, \
     get_attribute_emoji_by_monster
@@ -168,7 +168,7 @@ class PadInfo(commands.Cog, IdTest):
         }
 
         respond_with_child = [
-            (MonsterListMenu.MENU_TYPE, '\N{EYES}')
+            (MonsterListMenu.MENU_TYPE, MonsterListMenuPanes.emoji_name_to_emoji('expand'))
         ]
 
         menu_func = menu_map.get(menu_type)
@@ -603,7 +603,8 @@ class PadInfo(commands.Cog, IdTest):
                                      )
         parent_menu = MonsterListMenu.menu(original_author_id, friends, self.bot.user.id)
         message = await parent_menu.create(ctx, state)
-        child_message = await ctx.send('Click \N{EYES} to see a full menu embedded here.')
+        child_message = await ctx.send(
+            'Click {} to see a full menu embedded here.'.format(MonsterListMenuPanes.emoji_name_to_emoji('expand')))
         ims = state.serialize()
         user_config = await BotConfig.get_user(self.config, ctx.author.id)
         data = {

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -196,10 +196,10 @@ class PadInfo(commands.Cog, IdTest):
             if child_message_ims:
                 data['child_message_ims'] = child_message_ims
             ims['menu_type'] = IdMenu.MENU_TYPE
-            
+
             # The order here is really important!! The set of emojis attached to the ims is going to be changed in
             # the second transition, so it's VITAL that we reset prior to showing the child menu.
-            # It's also better from a perceived performance standard becuase the emojis are so rate-limited and
+            # It's also better from a perceived performance standpoint becuase the emojis are so rate-limited and
             # the reset wouldn't happen until all emojis showed up in the child, so this way it feels like everything
             # happens faster, but regardless the reset must happen first.
             await embed_menu.transition(message, ims, global_emoji_responses['reset'], member, **data)

--- a/padinfo/pane_names.py
+++ b/padinfo/pane_names.py
@@ -10,6 +10,7 @@ class IdMenuPaneNames:
 
 
 class MonsterListPaneNames:
+    expand = 'expand'
     refresh = 'refresh'
     reset = 'reset'
 

--- a/padinfo/pane_names.py
+++ b/padinfo/pane_names.py
@@ -10,6 +10,8 @@ class IdMenuPaneNames:
 
 
 class MonsterListPaneNames:
+    home = 'home'
+    id = 'id'
     refresh = 'refresh'
     reset = 'reset'
 

--- a/padinfo/pane_names.py
+++ b/padinfo/pane_names.py
@@ -11,3 +11,9 @@ class IdMenuPaneNames:
 
 class MonsterListPaneNames:
     refresh = 'refresh'
+    reset = 'reset'
+
+
+global_emoji_responses = {
+    'reset': '\N{WHITE MEDIUM STAR}'
+}

--- a/padinfo/pane_names.py
+++ b/padinfo/pane_names.py
@@ -10,7 +10,6 @@ class IdMenuPaneNames:
 
 
 class MonsterListPaneNames:
-    expand = 'expand'
     refresh = 'refresh'
     reset = 'reset'
 

--- a/padinfo/pane_names.py
+++ b/padinfo/pane_names.py
@@ -6,3 +6,8 @@ class IdMenuPaneNames:
     pantheon = 'pantheon'
     pic = 'pic'
     refresh = 'refresh'
+    delete = 'delete'
+
+
+class MonsterListPaneNames:
+    refresh = 'refresh'

--- a/padinfo/pane_names.py
+++ b/padinfo/pane_names.py
@@ -5,3 +5,4 @@ class IdMenuPaneNames:
     otherinfo = 'otherinfo'
     pantheon = 'pantheon'
     pic = 'pic'
+    refresh = 'refresh'

--- a/padinfo/reaction_list.py
+++ b/padinfo/reaction_list.py
@@ -17,7 +17,6 @@ async def get_id_menu_initial_reaction_list(ctx, dgcog, monster: "MonsterModel",
     # hide some panes if we're in evo scroll mode
     if not full_reaction_list:
         full_reaction_list = [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
-    print(full_reaction_list)
     if not force_evoscroll and not settings.checkEvoID(ctx.author.id):
         return full_reaction_list
     alt_versions, gem_versions = await EvosViewState.query(dgcog, monster)

--- a/padinfo/reaction_list.py
+++ b/padinfo/reaction_list.py
@@ -1,0 +1,35 @@
+from typing import List, Optional, TYPE_CHECKING
+
+from discordmenu.emoji.emoji_cache import emoji_cache
+
+from padinfo.core.padinfo_settings import settings
+from padinfo.id_menu import IdMenuPanes, IdMenu
+from padinfo.view_state.evos import EvosViewState
+from padinfo.view_state.materials import MaterialsViewState
+from padinfo.view_state.pantheon import PantheonViewState
+
+if TYPE_CHECKING:
+    from dadguide.models.monster_model import MonsterModel
+
+
+async def get_id_menu_initial_reaction_list(ctx, dgcog, monster: "MonsterModel",
+                                            full_reaction_list: List[Optional[str]] = None, force_evoscroll=False):
+    # hide some panes if we're in evo scroll mode
+    if not full_reaction_list:
+        full_reaction_list = [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
+    print(full_reaction_list)
+    if not force_evoscroll and not settings.checkEvoID(ctx.author.id):
+        return full_reaction_list
+    alt_versions, gem_versions = await EvosViewState.query(dgcog, monster)
+    if alt_versions is None:
+        full_reaction_list[full_reaction_list.index(IdMenuPanes.DATA[IdMenu.respond_with_left][0])] = None
+        full_reaction_list[full_reaction_list.index(IdMenuPanes.DATA[IdMenu.respond_with_right][0])] = None
+        full_reaction_list[full_reaction_list.index(IdMenuPanes.DATA[IdMenu.respond_with_evos][0])] = None
+    pantheon_list, series_name = await PantheonViewState.query(dgcog, monster)
+    if pantheon_list is None:
+        full_reaction_list[full_reaction_list.index(IdMenuPanes.DATA[IdMenu.respond_with_pantheon][0])] = None
+    mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link, gem_override = \
+        await MaterialsViewState.query(dgcog, monster)
+    if mats is None:
+        full_reaction_list[full_reaction_list.index(IdMenuPanes.DATA[IdMenu.respond_with_mats][0])] = None
+    return list(filter(None, full_reaction_list))

--- a/padinfo/view/components/monster/header.py
+++ b/padinfo/view/components/monster/header.py
@@ -45,9 +45,10 @@ class MonsterHeader:
         return LinkedText(msg, puzzledragonx(m)) if link else Text(msg)
 
     @staticmethod
-    def short_with_emoji(m: "MonsterModel", link=True):
+    def short_with_emoji(m: "MonsterModel", link=True, prefix=None):
         msg = f"{m.monster_no_na} - {m.name_en}"
         return Box(
+            prefix,
             Text(get_attribute_emoji_by_monster(m)),
             LinkedText(msg, puzzledragonx(m)) if link else Text(msg),
             Text(MonsterHeader.jp_suffix(m, False)),

--- a/padinfo/view/monster_list.py
+++ b/padinfo/view/monster_list.py
@@ -1,6 +1,7 @@
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedMain, EmbedField
 from discordmenu.embed.view import EmbedView
+from tsutils import char_to_emoji
 
 from padinfo.view.components.base import pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
@@ -11,8 +12,8 @@ def _monster_list(monsters):
     if not len(monsters):
         return []
     return [
-        MonsterHeader.short_with_emoji(mon, link=True)
-        for mon in sorted(monsters, key=lambda x: int(x.monster_id))
+        MonsterHeader.short_with_emoji(mon, link=True, prefix=char_to_emoji(i))
+        for i, mon in enumerate(monsters)
     ]
 
 

--- a/padinfo/view_state/id.py
+++ b/padinfo/view_state/id.py
@@ -14,11 +14,13 @@ class IdViewState(ViewStateBaseId):
                  transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters: List["MonsterModel"],
                  use_evo_scroll: bool = True,
                  reaction_list: List[str] = None,
+                 is_child: bool = False,
                  extra_state=None):
         super().__init__(original_author_id, menu_type, raw_query, query, color, monster,
                          use_evo_scroll=use_evo_scroll,
                          reaction_list=reaction_list,
                          extra_state=extra_state)
+        self.is_child = is_child
         self.acquire_raw = acquire_raw
         self.alt_monsters = alt_monsters
         self.base_rarity = base_rarity
@@ -29,6 +31,7 @@ class IdViewState(ViewStateBaseId):
         ret = super().serialize()
         ret.update({
             'pane_type': IdMenuPaneNames.id,
+            'is_child': str(self.is_child)
         })
         return ret
 
@@ -48,11 +51,13 @@ class IdViewState(ViewStateBaseId):
         original_author_id = ims['original_author_id']
         use_evo_scroll = ims.get('use_evo_scroll') != 'False'
         reaction_list = get_reaction_list_from_ims(ims)
+        is_child = bool(ims.get('is_child'))
 
         return cls(original_author_id, menu_type, raw_query, query, user_config.color, monster,
                    transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters,
                    use_evo_scroll=use_evo_scroll,
                    reaction_list=reaction_list,
+                   is_child=is_child,
                    extra_state=ims)
 
     @staticmethod

--- a/padinfo/view_state/monster_list.py
+++ b/padinfo/view_state/monster_list.py
@@ -13,9 +13,12 @@ class MonsterListViewState(ViewStateBase):
     def __init__(self, original_author_id, menu_type, raw_query, query, color,
                  monster_list: List["MonsterModel"], title,
                  reaction_list=None,
-                 extra_state=None):
+                 extra_state=None,
+                 child_message_id=None
+                 ):
         super().__init__(original_author_id, menu_type, raw_query,
                          extra_state=extra_state)
+        self.child_message_id = child_message_id
         self.title = title
         self.monster_list = monster_list
         self.reaction_list = reaction_list
@@ -29,6 +32,7 @@ class MonsterListViewState(ViewStateBase):
             'title': self.title,
             'monster_list': [str(m.monster_no) for m in self.monster_list],
             'reaction_list': ','.join(self.reaction_list) if self.reaction_list else None,
+            'child_message_id': self.child_message_id
         })
         return ret
 
@@ -44,8 +48,11 @@ class MonsterListViewState(ViewStateBase):
         original_author_id = ims['original_author_id']
         menu_type = ims['menu_type']
         reaction_list = get_reaction_list_from_ims(ims)
+        child_message_id = ims.get('child_message_id')
 
         return MonsterListViewState(original_author_id, menu_type, raw_query, query, user_config.color,
                                     monster_list=monster_list, title=title,
                                     reaction_list=reaction_list,
-                                    extra_state=ims)
+                                    extra_state=ims,
+                                    child_message_id=child_message_id
+                                    )


### PR DESCRIPTION
This PR makes evolist behave basically the same way as disambig, so now the only functionality left required for disambig is the logic to generate the list of monsters, though as a start at least we could take the same thing that's currently showing in `^idtraceback` (#738).

Currently there is one big problem with this PR which is that the emojis are showing up in a random order in the child menu, however I think it requires a change to discord-menu to resolve, as the emoji_diff here is a dict: https://github.com/TsubakiBotPad/discord-menu/blob/main/discordmenu/discord_client.py#L47

Resolves https://github.com/TsubakiBotPad/discord-menu/issues/1