### PR TITLE
Add extra info about transforming cards to id

### DIFF
--- a/padinfo/view/id.py
+++ b/padinfo/view/id.py
@@ -131,9 +131,19 @@ class IdView:
         return header
 
     @staticmethod
-    def active_skill_header(m: "MonsterModel"):
+    def active_skill_header(m: "MonsterModel", transform_base):
         active_skill = m.active_skill
-        active_cd = "({} -> {})".format(active_skill.turn_max, active_skill.turn_min) if active_skill else 'None'
+        if m==transform_base:
+            active_cd = "({} -> {})".format(active_skill.turn_max, active_skill.turn_min) \
+                if active_skill else 'None'
+        else:
+            base_skill = transform_base.active_skill
+            base_cd = ' (\N{DOWN-POINTING RED TRIANGLE} {} -> {})'.format(base_skill.turn_max,
+                                                                           base_skill.turn_min) \
+                if base_skill else 'None'
+
+            active_cd = '({} cd)'.format(active_skill.turn_min) if active_skill else 'None'
+            active_cd += base_cd
         return Box(
             BoldText('Active Skill'),
             BoldText(active_cd),
@@ -170,7 +180,7 @@ class IdView:
                 inline=True
             ),
             EmbedField(
-                IdView.active_skill_header(m).to_markdown(),
+                IdView.active_skill_header(m, state.transform_base).to_markdown(),
                 Text(m.active_skill.desc if m.active_skill else 'None')
             ),
             EmbedField(

--- a/padinfo/view/id.py
+++ b/padinfo/view/id.py
@@ -60,13 +60,22 @@ class IdView:
             delimiter=' ') if len(super_awakenings_emojis) > 0 else None
 
     @staticmethod
-    def all_awakenings_row(m: "MonsterModel"):
+    def all_awakenings_row(m: "MonsterModel", transform_base):
         if len(m.awakenings) == 0:
             return Box(Text('No Awakenings'))
 
         return Box(
-            IdView.normal_awakenings_row(m),
-            IdView.super_awakenings_row(m)
+            Box(
+                '\N{UP-POINTING RED TRIANGLE}' if m!=transform_base else '',
+                IdView.normal_awakenings_row(m),
+                delimiter=' '
+            ),
+            Box(
+                '\N{DOWN-POINTING RED TRIANGLE}',
+                IdView.all_awakenings_row(transform_base, transform_base),
+                delimiter=' '
+            ) if m!=transform_base else None,
+            IdView.super_awakenings_row(m),
         )
 
     @staticmethod
@@ -146,7 +155,7 @@ class IdView:
             EmbedField(
                 '/'.join(['{}'.format(t.name) for t in m.types]),
                 Box(
-                    IdView.all_awakenings_row(m),
+                    IdView.all_awakenings_row(m, state.transform_base),
                     IdView.killers_row(m, state.transform_base)
                 )
             ),

--- a/padinfo/view/transforminfo.py
+++ b/padinfo/view/transforminfo.py
@@ -31,15 +31,6 @@ def base_info(m: "MonsterModel"):
         IdView.super_awakenings_row(m)
     )
 
-def transform_skill_header(m: "MonsterModel"):
-    active_skill = m.active_skill
-    active_cd = '({} cd)'.format(active_skill.turn_min) if active_skill else 'None'
-    return Box(
-        BoldText('Active Skill'),
-        BoldText(active_cd),
-        delimiter=' '
-    )
-
 def base_skill(m: "MonsterModel"):
     active_skill = m.active_skill
     return (" (" + BASE_EMOJI + " "
@@ -75,7 +66,7 @@ class TransformInfoView:
                 inline=True
             ),
             EmbedField(
-                transform_skill_header(transformed_mon).to_markdown() + base_skill(base_mon),
+                IdView.active_skill_header(transformed_mon, base_mon).to_markdown(),
                 Text(transformed_mon.active_skill.desc if transformed_mon.active_skill else 'None')
             ),
             EmbedField(


### PR DESCRIPTION
Resolves #763.

For a transforming card:
- Adds the base's awakenings below the awakenings.
- Adds 🔺 and 🔻 before the transform and base card's awakenings.
- Uses 🔻 to represent base killers and base active cd.
- Represents transform actives simply with `# cd`.

As a side effect, transforminfoview uses the newly-modified active_skill_header method in idview instead of the custom transform_skill_header it used to.