### PR TITLE
Remove case-insensitivity aliases from Id

### DIFF
--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -257,7 +257,7 @@ class PadInfo(commands.Cog, IdTest):
         else:
             await self.send_id_failure_message(ctx, query)
 
-    @commands.command(name="id", aliases=["iD", "Id", "ID"])
+    @commands.command(name="id")
     @checks.bot_has_permissions(embed_links=True)
     async def _id(self, ctx, *, query: str):
         """Monster info (main tab)"""


### PR DESCRIPTION
The new redbot update made them look terrible in the help docs screen for the command
![image](https://user-images.githubusercontent.com/18037011/108479521-76768000-725b-11eb-8b83-53ba4ead07fd.png)
