### PR TITLE
Add problematic series token set to fix sonia etc

### DIFF
--- a/dadguide/monster_index.py
+++ b/dadguide/monster_index.py
@@ -6,8 +6,8 @@ import re
 from collections import defaultdict
 
 import aiohttp
-from redbot.core.utils import AsyncIter
 import tsutils
+from redbot.core.utils import AsyncIter
 
 from .token_mappings import *
 
@@ -22,6 +22,7 @@ TREE_MODIFIER_OVERRIDE_SHEET = SHEETS_PATTERN.format('1372419168')
 
 logger = logging.getLogger('red.pad-cogs.dadguide.monster_index')
 
+
 class MonsterIndex(tsutils.aobject):
     async def __ainit__(self, monsters, db):
         self.graph = db.graph
@@ -29,9 +30,10 @@ class MonsterIndex(tsutils.aobject):
         self.monster_id_to_nickname = defaultdict(set)
         self.monster_id_to_nametokens = defaultdict(set)
         self.monster_id_to_treename = defaultdict(set)
-        self.series_id_to_pantheon_nickname = defaultdict(set, {m.series_id: {m.series.name_en.lower().replace(" ", "")}
-                                                                for m
-                                                                in db.get_all_monsters()})
+        self.series_id_to_pantheon_nickname = \
+            defaultdict(set, {m.series_id: {m.series.name_en.lower().replace(" ", "")}
+                              for m in db.get_all_monsters()
+                              if m.series.name_en.lower() not in HAZARDOUS_IN_NAME_PREFIXES})
 
         self.mwtoken_creators = defaultdict(set)
 
@@ -112,7 +114,6 @@ class MonsterIndex(tsutils.aobject):
                     aliases = get_modifier_aliases(mod)
                     for emid in self.graph.get_alt_ids_by_id(mid):
                         self.manual_prefixes[emid].update(aliases)
-
 
         self._known_mods = {x for xs in self.series_id_to_pantheon_nickname.values()
                             for x in xs}.union(KNOWN_MODIFIERS)
@@ -240,7 +241,7 @@ class MonsterIndex(tsutils.aobject):
         # Replacements
         for ts in (k for k in self.replacement_tokens if token.lower() in k and all(m in token_dict[t] for t in k)):
             for t in self.replacement_tokens[ts]:
-                self.add_name_token(token_dict, t, m, depth-1)
+                self.add_name_token(token_dict, t, m, depth - 1)
 
     @staticmethod
     def _name_to_tokens(oname):
@@ -434,6 +435,7 @@ def copydict(token_dict):
         copy[k] = v.copy()
     return copy
 
+
 def combine_tokens_dicts(d1, *ds):
     combined = defaultdict(set, d1.copy())
     for d2 in ds:
@@ -445,6 +447,7 @@ def combine_tokens_dicts(d1, *ds):
 def token_count(tstr):
     tstr = re.sub(r"\(.+\)", "", tstr)
     return len(re.split(r'\W+', tstr))
+
 
 def get_modifier_aliases(mod):
     output = {mod}

--- a/dadguide/monster_index.py
+++ b/dadguide/monster_index.py
@@ -33,7 +33,7 @@ class MonsterIndex(tsutils.aobject):
         self.series_id_to_pantheon_nickname = \
             defaultdict(set, {m.series_id: {m.series.name_en.lower().replace(" ", "")}
                               for m in db.get_all_monsters()
-                              if m.series.name_en.lower() not in HAZARDOUS_IN_NAME_PREFIXES})
+                              if m.series.name_en.lower() not in HAZARDOUS_IN_NAME_MODS})
 
         self.mwtoken_creators = defaultdict(set)
 
@@ -211,7 +211,7 @@ class MonsterIndex(tsutils.aobject):
                     for mevo in alt_monsters:
                         if not mevo.is_equip:
                             for token2 in self._get_important_tokens(mevo.name_en, treenames):
-                                if token2 not in HAZARDOUS_IN_NAME_PREFIXES:
+                                if token2 not in HAZARDOUS_IN_NAME_MODS:
                                     self.add_name_token(self.name_tokens, token2, m)
 
             # Fluff tokens
@@ -235,7 +235,7 @@ class MonsterIndex(tsutils.aobject):
             return
 
         token_dict[token.lower()].add(m)
-        if token.lower() in self._known_mods and token.lower() not in HAZARDOUS_IN_NAME_PREFIXES:
+        if token.lower() in self._known_mods and token.lower() not in HAZARDOUS_IN_NAME_MODS:
             self.modifiers[m].add(token.lower())
 
         # Replacements

--- a/dadguide/monster_index.py
+++ b/dadguide/monster_index.py
@@ -33,7 +33,7 @@ class MonsterIndex(tsutils.aobject):
         self.series_id_to_pantheon_nickname = \
             defaultdict(set, {m.series_id: {m.series.name_en.lower().replace(" ", "")}
                               for m in db.get_all_monsters()
-                              if m.series.name_en.lower() not in HAZARDOUS_IN_NAME_MODS})
+                              if m.series.name_en.lower() not in PROBLEMATIC_SERIES_TOKENS})
 
         self.mwtoken_creators = defaultdict(set)
 

--- a/dadguide/token_mappings.py
+++ b/dadguide/token_mappings.py
@@ -312,7 +312,9 @@ LEGAL_END_TOKENS = {
 HAZARDOUS_IN_NAME_MODS = {
     "reincarnated",
     "awoken",
+}
 
+PROBLEMATIC_SERIES_TOKENS = {
     "sonia",
     "odin",
     "metatron",

--- a/dadguide/token_mappings.py
+++ b/dadguide/token_mappings.py
@@ -308,7 +308,8 @@ LEGAL_END_TOKENS = {
     "eq",
 }
 
-HAZARDOUS_IN_NAME_PREFIXES = {
+# These tokens have been found to be harmful and will only be added to monsters explicitly.
+HAZARDOUS_IN_NAME_MODS = {
     "reincarnated",
     "awoken",
 

--- a/dadguide/token_mappings.py
+++ b/dadguide/token_mappings.py
@@ -311,6 +311,13 @@ LEGAL_END_TOKENS = {
 HAZARDOUS_IN_NAME_PREFIXES = {
     "reincarnated",
     "awoken",
+
+    "sonia",
+    "odin",
+    "metatron",
+    "kali",
+    "fenrir",
+    "sherias",
 }
 
 ID1_SUPPORTED = {'hw', 'h', 'x', 'ny', 'gh', 'v', 'np', 'ma', 'a', 'r', 'rr', 'rg', 'rb', 'rl', 'rd', 'rx', 'b', 'br',


### PR DESCRIPTION
These gfes share name tokens with cards frequently and were problematically causing conflicts. For example:
![image](https://user-images.githubusercontent.com/18037011/108616053-9dee5980-73cf-11eb-97e6-0a86c215f952.png)

In order to make them still queryable, we are adding series tokens in the gdoc, for example `soniagfe` etc
