### PR TITLE
Display more information in transforminfo

### DIFF
--- a/padinfo/core/transforminfo.py
+++ b/padinfo/core/transforminfo.py
@@ -7,7 +7,7 @@ async def perform_transforminfo_query(dgcog, raw_query):
     found_monster = await find_monster(dgcog, raw_query)
 
     if not found_monster:
-        return None, None
+        return None, None, None
 
     transformed_mon = None
     base_mon = None
@@ -20,6 +20,16 @@ async def perform_transforminfo_query(dgcog, raw_query):
                 break
 
     if not transformed_mon:
-        return found_monster, transformed_mon
+        return found_monster, None, None
 
-    return base_mon, transformed_mon
+    reaction_ids = [base_mon.monster_id, transformed_mon.monster_id]
+    current_id = transformed_mon.monster_id
+    while True:
+        next_transform_id = mgraph.get_next_transform_id_by_monster_id(current_id)
+        if next_transform_id is not None and next_transform_id not in reaction_ids:
+            reaction_ids.append(next_transform_id)
+            current_id = next_transform_id
+        else:
+            break
+
+    return base_mon, transformed_mon, reaction_ids

--- a/padinfo/menu/transforminfo.py
+++ b/padinfo/menu/transforminfo.py
@@ -65,5 +65,5 @@ class TransformInfoMenuPanes(MenuPanes):
     DATA = {
         TransformInfoMenu.respond_with_overview: (emoji_buttons['home'], TransformInfoView.VIEW_TYPE),
         TransformInfoMenu.respond_with_base: ('\N{DOWN-POINTING RED TRIANGLE}', IdView.VIEW_TYPE),
-        TransformInfoMenu.respond_with_transform: ('\N{BLACK RIGHT-POINTING TRIANGLE}', IdView.VIEW_TYPE),
+        TransformInfoMenu.respond_with_transform: ('\N{UP-POINTING RED TRIANGLE}', IdView.VIEW_TYPE),
     }

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -762,7 +762,7 @@ class PadInfo(commands.Cog, IdTest):
     async def transforminfo(self, ctx, *, query):
         """Show info about a transform card, including some helpful details about the base card."""
         dgcog = await self.get_dgcog()
-        base_mon, transformed_mon = await perform_transforminfo_query(dgcog, query)
+        base_mon, transformed_mon, reaction_ids = await perform_transforminfo_query(dgcog, query)
 
         if not base_mon:
             await self.send_id_failure_message(ctx, query)

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -769,9 +769,9 @@ class PadInfo(commands.Cog, IdTest):
             return
 
         if not transformed_mon:
-            await ctx.send(
-                'Your query `{}` found [{}] {}, '.format(query, base_mon.monster_id,
-                                                         base_mon.name_en) + 'which has no evos that transform.')
+            await ctx.send('Your query `{}` '.format(query)
+                           + 'found [{}] {}, '.format(base_mon.monster_id, base_mon.name_en)
+                           + 'which has no evos that transform.')
             return
 
         color = await self.get_user_embed_color(ctx)


### PR DESCRIPTION
Makes progress toward #764.

This adds the full text of the base and transform card's active and leader skills, and the stat gain upon transformation, to `[p]transformfinfo`.