### PR TITLE
Fix auto-treetoken for trees with equips

### DIFF
--- a/dadguide/monster_index.py
+++ b/dadguide/monster_index.py
@@ -153,7 +153,7 @@ class MonsterIndex(tsutils.aobject):
             nametokens = self._name_to_tokens(m.name_en)
             last_token = m.name_en.split(',')[-1].strip()
             alt_monsters = self.graph.get_alt_monsters(m)
-            autotoken = len(alt_monsters) > 1
+            autotoken = len(me for me in alt_monsters if not me.is_equip) > 1
 
             for jpt in m.name_ja.split(" "):
                 self.name_tokens[jpt].add(m)

--- a/dadguide/monster_index.py
+++ b/dadguide/monster_index.py
@@ -160,13 +160,13 @@ class MonsterIndex(tsutils.aobject):
 
             # Propagate name tokens throughout all evos
             for me in alt_monsters:
-                if tsutils.contains_ja(me.name_en):
-                    continue
-                if last_token != me.name_en.split(',')[-1].strip():
-                    autotoken = False
                 for t in self.monster_id_to_nametokens[me.monster_id]:
                     if t in nametokens:
                         self.add_name_token(self.name_tokens, t, m)
+                if me.is_equip or tsutils.contains_ja(me.name_en):
+                    continue
+                if last_token != me.name_en.split(',')[-1].strip():
+                    autotoken = False
 
             # Find likely treenames
             treenames = set()


### PR DESCRIPTION
Closes #893

Auto-treetokenizing was added in a previous PR, but this PR allows it to ignore equips as they often have non-standard naming conventions.

<img width="550" alt="Screen Shot 2021-02-25 at 9 58 24 AM" src="https://user-images.githubusercontent.com/4073569/109188476-39752680-7750-11eb-927e-857182c53350.png">
