### PR TITLE
Add list of evos to every tab of id

### DIFF
--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -317,15 +317,15 @@ class PadInfo(commands.Cog, IdTest):
         if await self.config.do_survey():
             asyncio.create_task(self.send_survey_after(ctx, query, monster))
 
-        transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters = \
+        alt_monsters = IdViewState.get_alt_monsters(dgcog, monster)
+        transform_base, true_evo_type_raw, acquire_raw, base_rarity = \
             await IdViewState.query(dgcog, monster)
         full_reaction_list = [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
         initial_reaction_list = await get_id_menu_initial_reaction_list(ctx, dgcog, monster, full_reaction_list)
 
-        state = IdViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
-                            monster, transform_base, true_evo_type_raw, acquire_raw, base_rarity, alt_monsters,
-                            use_evo_scroll=settings.checkEvoID(ctx.author.id),
-                            reaction_list=initial_reaction_list)
+        state = IdViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color, monster, alt_monsters,
+                            transform_base, true_evo_type_raw, acquire_raw, base_rarity,
+                            use_evo_scroll=settings.checkEvoID(ctx.author.id), reaction_list=initial_reaction_list)
         menu = IdMenu.menu()
         await menu.create(ctx, state)
 
@@ -409,7 +409,7 @@ class PadInfo(commands.Cog, IdTest):
         initial_reaction_list = await get_id_menu_initial_reaction_list(ctx, dgcog, monster, full_reaction_list)
 
         state = EvosViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
-                              monster, alt_versions, gem_versions,
+                              monster, alt_versions, alt_versions, gem_versions,
                               reaction_list=initial_reaction_list,
                               use_evo_scroll=settings.checkEvoID(ctx.author.id))
         menu = IdMenu.menu(initial_control=IdMenu.evos_control)
@@ -436,10 +436,11 @@ class PadInfo(commands.Cog, IdTest):
             await ctx.send(inline("This monster has no mats or skillups and isn't used in any evolutions"))
             return
 
+        alt_monsters = MaterialsViewState.get_alt_monsters(dgcog, monster)
         full_reaction_list = [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
         initial_reaction_list = await get_id_menu_initial_reaction_list(ctx, dgcog, monster, full_reaction_list)
 
-        state = MaterialsViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color, monster,
+        state = MaterialsViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color, monster, alt_monsters,
                                    mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link, gem_override,
                                    reaction_list=initial_reaction_list,
                                    use_evo_scroll=settings.checkEvoID(ctx.author.id))
@@ -465,12 +466,12 @@ class PadInfo(commands.Cog, IdTest):
         if pantheon_list is None:
             await ctx.send(inline('Too many monsters in this series to display'))
             return
-
+        alt_monsters = PantheonViewState.get_alt_monsters(dgcog, monster)
         full_reaction_list = [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
         initial_reaction_list = await get_id_menu_initial_reaction_list(ctx, dgcog, monster, full_reaction_list)
 
         state = PantheonViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
-                                  monster, pantheon_list, series_name,
+                                  monster, alt_monsters, pantheon_list, series_name,
                                   reaction_list=initial_reaction_list,
                                   use_evo_scroll=settings.checkEvoID(ctx.author.id))
         menu = IdMenu.menu(initial_control=IdMenu.pantheon_control)
@@ -491,11 +492,12 @@ class PadInfo(commands.Cog, IdTest):
             await self.send_id_failure_message(ctx, query)
             return
 
+        alt_monsters = PicViewState.get_alt_monsters(dgcog, monster)
         full_reaction_list = [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
         initial_reaction_list = await get_id_menu_initial_reaction_list(ctx, dgcog, monster, full_reaction_list)
 
         state = PicViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
-                             monster,
+                             monster, alt_monsters,
                              reaction_list=initial_reaction_list,
                              use_evo_scroll=settings.checkEvoID(ctx.author.id))
         menu = IdMenu.menu(initial_control=IdMenu.pic_control)
@@ -516,11 +518,12 @@ class PadInfo(commands.Cog, IdTest):
             await self.send_id_failure_message(ctx, query)
             return
 
+        alt_monsters = PicViewState.get_alt_monsters(dgcog, monster)
         full_reaction_list = [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
         initial_reaction_list = await get_id_menu_initial_reaction_list(ctx, dgcog, monster, full_reaction_list)
 
         state = OtherInfoViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
-                                   monster,
+                                   monster, alt_monsters,
                                    reaction_list=initial_reaction_list,
                                    use_evo_scroll=settings.checkEvoID(ctx.author.id))
         menu = IdMenu.menu(initial_control=IdMenu.otherinfo_control)

--- a/padinfo/view/evos.py
+++ b/padinfo/view/evos.py
@@ -6,11 +6,11 @@ from discordmenu.embed.view import EmbedView
 
 from padinfo.common.config import UserConfig
 from padinfo.common.external_links import puzzledragonx
+from padinfo.view.common import get_monster_from_ims
 from padinfo.view.components.base import pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
 from padinfo.view.components.view_state_base_id import ViewStateBaseId
-from padinfo.view.common import get_monster_from_ims
 
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
@@ -19,11 +19,14 @@ if TYPE_CHECKING:
 class EvosViewState(ViewStateBaseId):
     def __init__(self, original_author_id, menu_type, raw_query, query, color,
                  monster: "MonsterModel",
+
+                 # this param is needed to placate the superclass but we won't duplicate evos in this view
+                 _alt_monsters,
                  alt_versions: List["MonsterModel"], gem_versions: List["MonsterModel"],
                  reaction_list: List[str] = None,
                  use_evo_scroll: bool = True,
                  extra_state=None):
-        super().__init__(original_author_id, menu_type, raw_query, query, color, monster,
+        super().__init__(original_author_id, menu_type, raw_query, query, color, monster, alt_versions,
                          use_evo_scroll=use_evo_scroll,
                          reaction_list=reaction_list,
                          extra_state=extra_state)
@@ -46,7 +49,7 @@ class EvosViewState(ViewStateBaseId):
 
         if alt_versions is None:
             return None
-
+        alt_monsters = alt_versions
         raw_query = ims['raw_query']
         query = ims.get('query') or raw_query
         original_author_id = ims['original_author_id']
@@ -56,6 +59,7 @@ class EvosViewState(ViewStateBaseId):
 
         return cls(original_author_id, menu_type, raw_query, query, user_config.color,
                    monster,
+                   alt_monsters,
                    alt_versions, gem_versions,
                    reaction_list=reaction_list,
                    use_evo_scroll=use_evo_scroll,

--- a/padinfo/view/materials.py
+++ b/padinfo/view/materials.py
@@ -13,6 +13,7 @@ from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
 from padinfo.view.components.view_state_base_id import ViewStateBaseId
 from padinfo.view.common import get_monster_from_ims
+from padinfo.view.id import evos_embed_field
 
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
@@ -22,13 +23,14 @@ MAX_MONS_TO_SHOW = 5
 
 class MaterialsViewState(ViewStateBaseId):
     def __init__(self, original_author_id, menu_type, raw_query, query, color, monster: "MonsterModel",
+                 alt_monsters: List["MonsterModel"],
                  mats: List["MonsterModel"], usedin: List["MonsterModel"], gemid: Optional[str],
                  gemusedin: List["MonsterModel"], skillups: List["MonsterModel"], skillup_evo_count: int, link: str,
                  gem_override: bool,
                  use_evo_scroll: bool = True,
                  reaction_list: List[str] = None,
                  extra_state=None):
-        super().__init__(original_author_id, menu_type, raw_query, query, color, monster,
+        super().__init__(original_author_id, menu_type, raw_query, query, color, monster, alt_monsters,
                          reaction_list=reaction_list,
                          use_evo_scroll=use_evo_scroll,
                          extra_state=extra_state)
@@ -60,6 +62,7 @@ class MaterialsViewState(ViewStateBaseId):
         if mats is None:
             return None
 
+        alt_monsters = cls.get_alt_monsters(dgcog, monster)
         raw_query = ims['raw_query']
         query = ims.get('query') or raw_query
         menu_type = ims['menu_type']
@@ -67,7 +70,7 @@ class MaterialsViewState(ViewStateBaseId):
         use_evo_scroll = ims.get('use_evo_scroll') != 'False'
         reaction_list = ims.get('reaction_list')
 
-        return cls(original_author_id, menu_type, raw_query, query, user_config.color, monster,
+        return cls(original_author_id, menu_type, raw_query, query, user_config.color, monster, alt_monsters,
                    mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link, stackable,
                    use_evo_scroll=use_evo_scroll,
                    reaction_list=reaction_list,
@@ -165,5 +168,5 @@ class MaterialsView:
                 if state.gemusedin else None,
                 skillup_field(state.skillups, state.skillup_evo_count, state.link)
                 if not (state.monster.is_stackable or state.gem_override) else None
-            ] if f is not None]
+            ] if f is not None] + [evos_embed_field(state)]
         )

--- a/padinfo/view/otherinfo.py
+++ b/padinfo/view/otherinfo.py
@@ -10,8 +10,9 @@ from redbot.core.utils.chat_formatting import box
 from padinfo.common.external_links import puzzledragonx
 from padinfo.view.components.base import pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
-from padinfo.view.links import LinksView
 from padinfo.view.components.view_state_base_id import ViewStateBaseId
+from padinfo.view.id import evos_embed_field
+from padinfo.view.links import LinksView
 
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
@@ -79,4 +80,5 @@ class OtherInfoView:
                         Box(
                             LabeledText("Rarity", str(m.rarity)),
                             LabeledText("Cost", str(m.cost)),
-                            delimiter=' ')))])
+                            delimiter=' '))),
+                evos_embed_field(state)])

--- a/padinfo/view/pic.py
+++ b/padinfo/view/pic.py
@@ -8,6 +8,7 @@ from padinfo.view.components.base import pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
 from padinfo.view.components.view_state_base_id import ViewStateBaseId
+from padinfo.view.id import evos_embed_field
 
 
 class PicViewState(ViewStateBaseId):
@@ -45,7 +46,9 @@ class PicView:
                     delimiter=' '
                 ) if state.monster.orb_skin_id else None,
             )
-        )]
+        ),
+            evos_embed_field(state)
+        ]
 
         return EmbedView(
             EmbedMain(


### PR DESCRIPTION
This improves ease of seeing where you are for scrolling. Does not add this to the `evos` tab itself because that's super redundant.

![image](https://user-images.githubusercontent.com/18037011/109427440-1056cf00-79b8-11eb-8a85-ceec6ab2aaf5.png)
![image](https://user-images.githubusercontent.com/18037011/109427457-23699f00-79b8-11eb-9529-96edb899c6e7.png)

Unfortunately it's above the footer image for `^pic` but there's nothing to be done about this:
![image](https://user-images.githubusercontent.com/18037011/109427463-28c6e980-79b8-11eb-88c1-c8ee72d6e3d4.png)
