### PR TITLE
Use Emoji class instead of PaneNames

### DIFF
--- a/padinfo/menu/common.py
+++ b/padinfo/menu/common.py
@@ -13,7 +13,7 @@ class MenuPanes:
 
     @classmethod
     def emoji_names(cls):
-        return [k for k, v in cls.DATA.items() if v[1] not in cls.HIDDEN_EMOJIS]
+        return [k for k, v in cls.DATA.items() if k not in cls.HIDDEN_EMOJIS]
 
     @classmethod
     def transitions(cls):

--- a/padinfo/menu/id.py
+++ b/padinfo/menu/id.py
@@ -222,11 +222,6 @@ class IdMenu:
         )
 
 
-class IdMenuPaneNames:
-    refresh = 'refresh'
-    delete = 'delete'
-
-
 class IdMenuEmoji:
     left = '\N{BLACK LEFT-POINTING TRIANGLE}'
     right = '\N{BLACK RIGHT-POINTING TRIANGLE}'
@@ -250,10 +245,10 @@ class IdMenuPanes(MenuPanes):
         IdMenuEmoji.pic: (IdMenu.respond_with_picture, PicView.VIEW_TYPE),
         IdMenuEmoji.pantheon: (IdMenu.respond_with_pantheon, PantheonView.VIEW_TYPE),
         IdMenuEmoji.otherinfo: (IdMenu.respond_with_otherinfo, OtherInfoView.VIEW_TYPE),
-        IdMenuEmoji.refresh: (IdMenu.respond_with_refresh, IdMenuPaneNames.refresh),
-        IdMenuEmoji.delete: (IdMenu.respond_with_delete, IdMenuPaneNames.delete),
+        IdMenuEmoji.refresh: (IdMenu.respond_with_refresh, None),
+        IdMenuEmoji.delete: (IdMenu.respond_with_delete, None),
     }
     HIDDEN_EMOJIS = [
-        IdMenuPaneNames.refresh,
-        IdMenuPaneNames.delete,
+        IdMenuEmoji.refresh,
+        IdMenuEmoji.delete,
     ]

--- a/padinfo/menu/monster_list.py
+++ b/padinfo/menu/monster_list.py
@@ -5,15 +5,9 @@ from discordmenu.embed.menu import EmbedMenu, EmbedControl
 from tsutils import char_to_emoji
 
 from padinfo.menu.common import emoji_buttons, MenuPanes
-from padinfo.menu.id import IdMenu, IdMenuPanes, IdMenuPaneNames, IdMenuEmoji
+from padinfo.menu.id import IdMenu, IdMenuPanes, IdMenuEmoji
 from padinfo.view.id import IdView
 from padinfo.view.monster_list import MonsterListView, MonsterListViewState
-
-
-class MonsterListPaneNames:
-    home = 'home'
-    refresh = 'refresh'
-    reset = 'reset'
 
 
 class MonsterListEmoji:
@@ -142,7 +136,7 @@ class MonsterListMenuPanes(MenuPanes):
     INITIAL_EMOJI = MonsterListEmoji.home
     DATA = {
         # tuple parts: parent_response, pane_type, respond_with_child
-        MonsterListEmoji.home: (MonsterListMenu.respond_with_monster_list, MonsterListPaneNames.home, None),
+        MonsterListEmoji.home: (MonsterListMenu.respond_with_monster_list, MonsterListEmoji.home, None),
         MonsterListEmoji.zero: (
             MonsterListMenu.respond_with_0, IdView.VIEW_TYPE, MonsterListMenu.click_child_number),
         MonsterListEmoji.one: (
@@ -166,14 +160,14 @@ class MonsterListMenuPanes(MenuPanes):
         MonsterListEmoji.ten: (
             MonsterListMenu.respond_with_10, IdView.VIEW_TYPE, MonsterListMenu.click_child_number),
         MonsterListEmoji.refresh: (
-            MonsterListMenu.respond_with_refresh, MonsterListPaneNames.refresh, None),
+            MonsterListMenu.respond_with_refresh, None, None),
         MonsterListEmoji.reset: (
-            MonsterListMenu.respond_with_reset, MonsterListPaneNames.reset, None)
+            MonsterListMenu.respond_with_reset, None, None)
     }
     HIDDEN_EMOJIS = [
-        MonsterListPaneNames.home,
-        MonsterListPaneNames.refresh,
-        MonsterListPaneNames.reset,
+        MonsterListEmoji.home,
+        MonsterListEmoji.refresh,
+        MonsterListEmoji.reset,
     ]
 
     @classmethod

--- a/padinfo/menu/series_scroll.py
+++ b/padinfo/menu/series_scroll.py
@@ -11,12 +11,6 @@ from padinfo.view.id import IdView
 from padinfo.view.series_scroll import SeriesScrollView, SeriesScrollViewState
 
 
-class SeriesScrollPaneNames:
-    home = 'home'
-    refresh = 'refresh'
-    reset = 'reset'
-
-
 class SeriesScrollEmoji:
     delete = '\N{CROSS MARK}'
     home = emoji_buttons['home']
@@ -278,7 +272,7 @@ class SeriesScrollMenuPanes(MenuPanes):
     DATA = {
         # tuple parts: emoji, pane_type, respond_with_parent, respond_with_child
         SeriesScrollEmoji.delete: (SeriesScrollMenu.respond_with_delete, None, None),
-        SeriesScrollEmoji.home: (SeriesScrollMenu.respond_with_monster_list, SeriesScrollPaneNames.home, None),
+        SeriesScrollEmoji.home: (SeriesScrollMenu.respond_with_monster_list, None, None),
         SeriesScrollEmoji.prev_page: (SeriesScrollMenu.respond_with_left, SeriesScrollView.VIEW_TYPE, None),
         SeriesScrollEmoji.prev_mon: (
             SeriesScrollMenu.respond_with_previous_monster, None, SeriesScrollMenu.auto_scroll_child_left),
@@ -307,13 +301,13 @@ class SeriesScrollMenuPanes(MenuPanes):
             SeriesScrollMenu.respond_with_9, IdView.VIEW_TYPE, SeriesScrollMenu.click_child_number),
         SeriesScrollEmoji.ten: (
             SeriesScrollMenu.respond_with_10, IdView.VIEW_TYPE, SeriesScrollMenu.click_child_number),
-        SeriesScrollEmoji.refresh: (SeriesScrollMenu.respond_with_refresh, SeriesScrollPaneNames.refresh, None),
-        SeriesScrollEmoji.reset: (SeriesScrollMenu.respond_with_reset, SeriesScrollPaneNames.reset, None)
+        SeriesScrollEmoji.refresh: (SeriesScrollMenu.respond_with_refresh, None, None),
+        SeriesScrollEmoji.reset: (SeriesScrollMenu.respond_with_reset, None, None)
     }
     HIDDEN_EMOJIS = [
-        SeriesScrollPaneNames.home,
-        SeriesScrollPaneNames.refresh,
-        SeriesScrollPaneNames.reset,
+        SeriesScrollEmoji.home,
+        SeriesScrollEmoji.refresh,
+        SeriesScrollEmoji.reset,
     ]
 
     @classmethod


### PR DESCRIPTION
There was a class "PaneNames" defined for some menus that was now doing basically the same thing as the new Emoji class, I refactored slightly to use Emoji instead for the purpose of seeing if emoji were to be hidden. Even though several menus were touched, the impact is very minimal and no one should really notice anything different.