### PR TITLE
Move control functions from Menus to ViewStates

### DIFF
--- a/padinfo/menu/id.py
+++ b/padinfo/menu/id.py
@@ -23,11 +23,9 @@ class IdMenu:
     MENU_TYPE = 'IdMenu'
 
     @staticmethod
-    def menu(initial_control=None):
-        if initial_control is None:
-            initial_control = IdMenu.id_control
+    def menu():
 
-        embed = EmbedMenu(IdMenuPanes.transitions(), initial_control,
+        embed = EmbedMenu(IdMenuPanes.transitions(),
                           delete_func=IdMenu.respond_with_delete)
         return embed
 
@@ -113,8 +111,7 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await IdViewState.deserialize(dgcog, user_config, ims)
-        control = IdMenu.id_control(view_state)
-        return control
+        return view_state.control()
 
     @staticmethod
     async def respond_with_evos(message: Optional[Message], ims, **data):
@@ -122,8 +119,7 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await EvosViewState.deserialize(dgcog, user_config, ims)
-        control = IdMenu.evos_control(view_state)
-        return control
+        return view_state.control()
 
     @staticmethod
     async def respond_with_mats(message: Optional[Message], ims, **data):
@@ -131,8 +127,7 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await MaterialsViewState.deserialize(dgcog, user_config, ims)
-        control = IdMenu.mats_control(view_state)
-        return control
+        return view_state.control()
 
     @staticmethod
     async def respond_with_picture(message: Optional[Message], ims, **data):
@@ -140,8 +135,7 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await PicViewState.deserialize(dgcog, user_config, ims)
-        control = IdMenu.pic_control(view_state)
-        return control
+        return view_state.control()
 
     @staticmethod
     async def respond_with_pantheon(message: Optional[Message], ims, **data):
@@ -149,8 +143,7 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await PantheonViewState.deserialize(dgcog, user_config, ims)
-        control = IdMenu.pantheon_control(view_state)
-        return control
+        return view_state.control()
 
     @staticmethod
     async def respond_with_otherinfo(message: Optional[Message], ims, **data):
@@ -158,8 +151,7 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await OtherInfoViewState.deserialize(dgcog, user_config, ims)
-        control = IdMenu.otherinfo_control(view_state)
-        return control
+        return view_state.control()
 
     @staticmethod
     def id_control(state: IdViewState):
@@ -168,56 +160,6 @@ class IdMenu:
         reaction_list = state.reaction_list
         return EmbedControl(
             [IdView.embed(state)],
-            reaction_list or [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
-        )
-
-    @staticmethod
-    def evos_control(state: Optional[EvosViewState]):
-        if state is None:
-            return None
-        reaction_list = state.reaction_list
-        return EmbedControl(
-            [EvosView.embed(state)],
-            reaction_list or [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
-        )
-
-    @staticmethod
-    def mats_control(state: Optional[MaterialsViewState]):
-        if state is None:
-            return None
-        reaction_list = state.reaction_list
-        return EmbedControl(
-            [MaterialsView.embed(state)],
-            reaction_list or [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
-        )
-
-    @staticmethod
-    def pic_control(state: PicViewState):
-        if state is None:
-            return None
-        reaction_list = state.reaction_list
-        return EmbedControl(
-            [PicView.embed(state)],
-            reaction_list or [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
-        )
-
-    @staticmethod
-    def pantheon_control(state: Optional[PantheonViewState]):
-        if state is None:
-            return None
-        reaction_list = state.reaction_list
-        return EmbedControl(
-            [PantheonView.embed(state)],
-            reaction_list or [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
-        )
-
-    @staticmethod
-    def otherinfo_control(state: OtherInfoViewState):
-        if state is None:
-            return None
-        reaction_list = state.reaction_list
-        return EmbedControl(
-            [OtherInfoView.embed(state)],
             reaction_list or [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]
         )
 

--- a/padinfo/menu/id.py
+++ b/padinfo/menu/id.py
@@ -111,6 +111,8 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await IdViewState.deserialize(dgcog, user_config, ims)
+        if view_state is None:
+            return None
         return view_state.control()
 
     @staticmethod
@@ -119,6 +121,8 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await EvosViewState.deserialize(dgcog, user_config, ims)
+        if view_state is None:
+            return None
         return view_state.control()
 
     @staticmethod
@@ -127,6 +131,8 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await MaterialsViewState.deserialize(dgcog, user_config, ims)
+        if view_state is None:
+            return None
         return view_state.control()
 
     @staticmethod
@@ -135,6 +141,8 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await PicViewState.deserialize(dgcog, user_config, ims)
+        if view_state is None:
+            return None
         return view_state.control()
 
     @staticmethod
@@ -143,6 +151,8 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await PantheonViewState.deserialize(dgcog, user_config, ims)
+        if view_state is None:
+            return None
         return view_state.control()
 
     @staticmethod
@@ -151,6 +161,8 @@ class IdMenu:
         user_config = data['user_config']
 
         view_state = await OtherInfoViewState.deserialize(dgcog, user_config, ims)
+        if view_state is None:
+            return None
         return view_state.control()
 
     @staticmethod

--- a/padinfo/menu/monster_list.py
+++ b/padinfo/menu/monster_list.py
@@ -1,13 +1,13 @@
 from typing import Optional
 
 from discord import Message
-from discordmenu.embed.menu import EmbedMenu, EmbedControl
+from discordmenu.embed.menu import EmbedMenu
 from tsutils import char_to_emoji
 
 from padinfo.menu.common import emoji_buttons, MenuPanes
 from padinfo.menu.id import IdMenu, IdMenuPanes, IdMenuEmoji
 from padinfo.view.id import IdView
-from padinfo.view.monster_list import MonsterListView, MonsterListViewState
+from padinfo.view.monster_list import MonsterListViewState
 
 
 class MonsterListEmoji:
@@ -32,10 +32,8 @@ class MonsterListMenu:
     CHILD_MENU_TYPE = 'IdMenu'
 
     @staticmethod
-    def menu(initial_control=None):
-        if initial_control is None:
-            initial_control = MonsterListMenu.monster_list_control
-        embed = EmbedMenu(MonsterListMenuPanes.transitions(), initial_control)
+    def menu():
+        embed = EmbedMenu(MonsterListMenuPanes.transitions())
         return embed
 
     @staticmethod
@@ -55,8 +53,7 @@ class MonsterListMenu:
         dgcog = data['dgcog']
         user_config = data['user_config']
         view_state = await MonsterListViewState.deserialize(dgcog, user_config, ims)
-        control = MonsterListMenu.monster_list_control(view_state)
-        return control
+        return view_state.control()
 
     @staticmethod
     async def respond_with_n(message: Optional[Message], ims, _n, **data):
@@ -107,17 +104,7 @@ class MonsterListMenu:
         return await MonsterListMenu.respond_with_n(message, ims, 10, **data)
 
     @staticmethod
-    def monster_list_control(state: MonsterListViewState):
-        if state is None:
-            return None
-        reaction_list = state.reaction_list
-        return EmbedControl(
-            [MonsterListView.embed(state)],
-            reaction_list
-        )
-
-    @staticmethod
-    def click_child_number(ims, emoji_clicked, **data):
+    def click_child_number(ims, emoji_clicked, **_data):
         emoji_response = IdMenuEmoji.refresh \
             if MonsterListMenuPanes.respond_to_emoji_with_child(emoji_clicked) else None
         if emoji_response is None:

--- a/padinfo/menu/monster_list.py
+++ b/padinfo/menu/monster_list.py
@@ -53,6 +53,8 @@ class MonsterListMenu:
         dgcog = data['dgcog']
         user_config = data['user_config']
         view_state = await MonsterListViewState.deserialize(dgcog, user_config, ims)
+        if view_state is None:
+            return None
         return view_state.control()
 
     @staticmethod

--- a/padinfo/menu/simple_text.py
+++ b/padinfo/menu/simple_text.py
@@ -18,7 +18,7 @@ class SimpleTextMenu:
 
     @staticmethod
     def menu():
-        embed = EmbedMenu(SimpleTextMenuPanes.transitions(), SimpleTextMenu.message_control,
+        embed = EmbedMenu(SimpleTextMenuPanes.transitions(),
                           delete_func=SimpleTextMenu.respond_with_delete)
         return embed
 
@@ -27,22 +27,11 @@ class SimpleTextMenu:
         dgcog = data.get('dgcog')
         user_config = data.get('user_config')
         view_state = await SimpleTextViewState.deserialize(dgcog, user_config, ims)
-        control = SimpleTextMenu.message_control(view_state)
-        return control
+        return view_state.control()
 
     @staticmethod
     async def respond_with_delete(message: Optional[Message], ims, **data):
         return await message.delete()
-
-    @staticmethod
-    def message_control(state: SimpleTextViewState):
-        if state is None:
-            return None
-        reaction_list = state.reaction_list
-        return EmbedControl(
-            [SimpleTextView.embed(state)],
-            reaction_list
-        )
 
 
 class SimpleTextEmoji:

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -412,7 +412,7 @@ class PadInfo(commands.Cog, IdTest):
                               monster, alt_versions, alt_versions, gem_versions,
                               reaction_list=initial_reaction_list,
                               use_evo_scroll=settings.checkEvoID(ctx.author.id))
-        menu = IdMenu.menu(initial_control=IdMenu.evos_control)
+        menu = IdMenu.menu()
         await menu.create(ctx, state)
 
     @commands.command(name="mats", aliases=['evomats', 'evomat', 'skillups'])
@@ -444,7 +444,7 @@ class PadInfo(commands.Cog, IdTest):
                                    mats, usedin, gemid, gemusedin, skillups, skillup_evo_count, link, gem_override,
                                    reaction_list=initial_reaction_list,
                                    use_evo_scroll=settings.checkEvoID(ctx.author.id))
-        menu = IdMenu.menu(initial_control=IdMenu.mats_control)
+        menu = IdMenu.menu()
         await menu.create(ctx, state)
 
     @commands.command(aliases=["series"])
@@ -474,7 +474,7 @@ class PadInfo(commands.Cog, IdTest):
                                   monster, alt_monsters, pantheon_list, series_name,
                                   reaction_list=initial_reaction_list,
                                   use_evo_scroll=settings.checkEvoID(ctx.author.id))
-        menu = IdMenu.menu(initial_control=IdMenu.pantheon_control)
+        menu = IdMenu.menu()
         await menu.create(ctx, state)
 
     @commands.command(aliases=['img'])
@@ -500,7 +500,7 @@ class PadInfo(commands.Cog, IdTest):
                              monster, alt_monsters,
                              reaction_list=initial_reaction_list,
                              use_evo_scroll=settings.checkEvoID(ctx.author.id))
-        menu = IdMenu.menu(initial_control=IdMenu.pic_control)
+        menu = IdMenu.menu()
         await menu.create(ctx, state)
 
     @commands.command(aliases=['stats'])
@@ -526,7 +526,7 @@ class PadInfo(commands.Cog, IdTest):
                                    monster, alt_monsters,
                                    reaction_list=initial_reaction_list,
                                    use_evo_scroll=settings.checkEvoID(ctx.author.id))
-        menu = IdMenu.menu(initial_control=IdMenu.otherinfo_control)
+        menu = IdMenu.menu()
         await menu.create(ctx, state)
 
     @commands.command()

--- a/padinfo/view/components/view_state_base_id.py
+++ b/padinfo/view/components/view_state_base_id.py
@@ -1,4 +1,7 @@
+import abc
 from typing import TYPE_CHECKING, List
+
+from discordmenu.embed.control import EmbedControl
 
 from padinfo.common.config import UserConfig
 from padinfo.view.common import get_monster_from_ims
@@ -55,6 +58,10 @@ class ViewStateBaseId:
         return cls(original_author_id, menu_type, raw_query, query, user_config.color, monster, alt_monsters,
                    use_evo_scroll=use_evo_scroll, reaction_list=reaction_list,
                    extra_state=ims)
+
+    @abc.abstractmethod
+    def control(self):
+        pass
 
     @classmethod
     def get_alt_monsters(cls, dgcog, monster):

--- a/padinfo/view/evos.py
+++ b/padinfo/view/evos.py
@@ -2,6 +2,7 @@ from typing import List, TYPE_CHECKING
 
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedThumbnail, EmbedMain, EmbedField
+from discordmenu.embed.control import EmbedControl
 from discordmenu.embed.view import EmbedView
 
 from padinfo.common.config import UserConfig
@@ -64,6 +65,12 @@ class EvosViewState(ViewStateBaseId):
                    reaction_list=reaction_list,
                    use_evo_scroll=use_evo_scroll,
                    extra_state=ims)
+
+    def control(self):
+        return EmbedControl(
+            [EvosView.embed(self)],
+            self.reaction_list
+        )
 
     @staticmethod
     async def query(dgcog, monster):

--- a/padinfo/view/id.py
+++ b/padinfo/view/id.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, List
 
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedThumbnail, EmbedMain, EmbedField
+from discordmenu.embed.control import EmbedControl
 from discordmenu.embed.text import Text, BoldText, LabeledText, HighlightableLinks, LinkedText
 from discordmenu.embed.view import EmbedView
 
@@ -73,6 +74,12 @@ class IdViewState(ViewStateBaseId):
                    reaction_list=reaction_list,
                    is_child=is_child,
                    extra_state=ims)
+
+    def control(self):
+        return EmbedControl(
+            [IdView.embed(self)],
+            self.reaction_list
+        )
 
     @classmethod
     async def query(cls, dgcog, monster):

--- a/padinfo/view/materials.py
+++ b/padinfo/view/materials.py
@@ -2,17 +2,18 @@ from typing import List, TYPE_CHECKING, Optional
 
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedThumbnail, EmbedMain, EmbedField
+from discordmenu.embed.control import EmbedControl
 from discordmenu.embed.text import LinkedText
 from discordmenu.embed.view import EmbedView
 
 from padinfo.common.config import UserConfig
 from padinfo.common.external_links import ilmina_skill
 from padinfo.common.external_links import puzzledragonx
+from padinfo.view.common import get_monster_from_ims
 from padinfo.view.components.base import pad_info_footer_with_state
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
 from padinfo.view.components.view_state_base_id import ViewStateBaseId
-from padinfo.view.common import get_monster_from_ims
 from padinfo.view.id import evos_embed_field
 
 if TYPE_CHECKING:
@@ -75,6 +76,12 @@ class MaterialsViewState(ViewStateBaseId):
                    use_evo_scroll=use_evo_scroll,
                    reaction_list=reaction_list,
                    extra_state=ims)
+
+    def control(self):
+        return EmbedControl(
+            [MaterialsView.embed(self)],
+            self.reaction_list
+        )
 
     @staticmethod
     async def query(dgcog, monster):

--- a/padinfo/view/monster_list.py
+++ b/padinfo/view/monster_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, List
 
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedMain, EmbedField
+from discordmenu.embed.control import EmbedControl
 from discordmenu.embed.view import EmbedView
 from tsutils import char_to_emoji
 
@@ -64,6 +65,12 @@ class MonsterListViewState(ViewStateBase):
                                     extra_state=ims,
                                     child_message_id=child_message_id
                                     )
+
+    def control(self):
+        return EmbedControl(
+            [MonsterListView.embed(self)],
+            self.reaction_list
+        )
 
 
 def _monster_list(monsters):

--- a/padinfo/view/otherinfo.py
+++ b/padinfo/view/otherinfo.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 import prettytable
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedMain, EmbedField
+from discordmenu.embed.control import EmbedControl
 from discordmenu.embed.text import LabeledText, Text
 from discordmenu.embed.view import EmbedView
 from redbot.core.utils.chat_formatting import box
@@ -25,6 +26,12 @@ class OtherInfoViewState(ViewStateBaseId):
             'pane_type': OtherInfoView.VIEW_TYPE,
         })
         return ret
+
+    def control(self):
+        return EmbedControl(
+            [OtherInfoView.embed(self)],
+            self.reaction_list
+        )
 
 
 def statsbox(m):

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -62,12 +62,6 @@ class PantheonViewState(ViewStateBaseId):
                    reaction_list=reaction_list,
                    extra_state=ims)
 
-    def control(self):
-        return EmbedControl(
-            [PantheonView.embed(self)],
-            self.reaction_list
-        )
-
     @classmethod
     async def query(cls, dgcog, monster):
         db_context = dgcog.database
@@ -81,6 +75,13 @@ class PantheonViewState(ViewStateBaseId):
         series_name = monster.series.name_en
 
         return pantheon_list, series_name
+
+
+def pantheon_control(state: PantheonViewState):
+    return EmbedControl(
+        [PantheonView.embed(state)],
+        state.reaction_list
+    )
 
 
 class PantheonView:

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, List
 
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedMain, EmbedField, EmbedThumbnail
+from discordmenu.embed.control import EmbedControl
 from discordmenu.embed.view import EmbedView
 
 from padinfo.common.config import UserConfig
@@ -60,6 +61,12 @@ class PantheonViewState(ViewStateBaseId):
                    use_evo_scroll=use_evo_scroll,
                    reaction_list=reaction_list,
                    extra_state=ims)
+
+    def control(self):
+        return EmbedControl(
+            [PantheonView.embed(self)],
+            self.reaction_list
+        )
 
     @classmethod
     async def query(cls, dgcog, monster):

--- a/padinfo/view/pic.py
+++ b/padinfo/view/pic.py
@@ -1,5 +1,6 @@
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedMain, EmbedField, EmbedBodyImage
+from discordmenu.embed.control import EmbedControl
 from discordmenu.embed.text import LinkedText, Text
 from discordmenu.embed.view import EmbedView
 
@@ -19,6 +20,12 @@ class PicViewState(ViewStateBaseId):
             'pane_type': PicView.VIEW_TYPE,
         })
         return ret
+
+    def control(self):
+        return EmbedControl(
+            [PicView.embed(self)],
+            self.reaction_list
+        )
 
 
 class PicView:

--- a/padinfo/view/simple_text.py
+++ b/padinfo/view/simple_text.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from discordmenu.embed.components import EmbedMain
+from discordmenu.embed.control import EmbedControl
 from discordmenu.embed.view import EmbedView
 
 from padinfo.common.config import UserConfig
@@ -30,6 +31,12 @@ class SimpleTextViewState(ViewStateBase):
         raw_query = ims.get('raw_query')
         return cls(original_author_id, menu_type, raw_query, user_config.color, ims.get('message'),
                    reaction_list=ims.get('reaction_list'))
+
+    def control(self):
+        return EmbedControl(
+            [SimpleTextView.embed(self)],
+            self.reaction_list
+        )
 
 
 class SimpleTextView:


### PR DESCRIPTION
Now that Views & ViewStates are in the same file, there's not really any import issues with this, and this prevents a lot of duplicate code because we are reusing view states across a lot of different types of menus.

**Also requires a discordmenu change to remove `initial_control` param**