### PR TITLE
Enable further transform emojis in transforminfo

### DIFF
--- a/padinfo/menu/transforminfo.py
+++ b/padinfo/menu/transforminfo.py
@@ -3,6 +3,7 @@ from typing import Optional
 from discord import Message
 from discordmenu.embed.menu import EmbedMenu, EmbedControl
 from discordmenu.emoji.emoji_cache import emoji_cache
+from tsutils import char_to_emoji
 
 from padinfo.menu.common import MenuPanes, emoji_buttons
 from padinfo.view.id import IdView, IdViewState
@@ -41,6 +42,12 @@ class TransformInfoMenu:
         return id_control
 
     @staticmethod
+    async def respond_with_n(message: Optional[Message], ims, **data):
+        dgcog = data['dgcog']
+        user_config = data['user_config']
+        # dummy for now
+
+    @staticmethod
     async def respond_with_overview(message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
         user_config = data['user_config']
@@ -67,6 +74,15 @@ class TransformInfoEmoji:
     home = emoji_buttons['home']
     down = '\N{DOWN-POINTING RED TRIANGLE}'
     up = '\N{UP-POINTING RED TRIANGLE}'
+    two = char_to_emoji('2')
+    three = char_to_emoji('3')
+    four = char_to_emoji('4')
+    five = char_to_emoji('5')
+    six = char_to_emoji('6')
+    seven = char_to_emoji('7')
+    eight = char_to_emoji('8')
+    nine = char_to_emoji('9')
+    ten = char_to_emoji('10')
 
 
 class TransformInfoMenuPanes(MenuPanes):
@@ -75,4 +91,17 @@ class TransformInfoMenuPanes(MenuPanes):
                                   TransformInfoView.VIEW_TYPE),
         TransformInfoEmoji.down: (TransformInfoMenu.respond_with_base, IdView.VIEW_TYPE),
         TransformInfoEmoji.up: (TransformInfoMenu.respond_with_transform, IdView.VIEW_TYPE),
+        TransformInfoEmoji.two: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
+        TransformInfoEmoji.three: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
+        TransformInfoEmoji.four: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
+        TransformInfoEmoji.five: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
+        TransformInfoEmoji.six: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
+        TransformInfoEmoji.seven: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
+        TransformInfoEmoji.eight: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
+        TransformInfoEmoji.nine: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
+        TransformInfoEmoji.ten: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
     }
+
+    @classmethod
+    def get_reaction_list(cls, number_of_further_transforms: int):
+        return cls.emoji_names()[:number_of_further_transforms]

--- a/padinfo/menu/transforminfo.py
+++ b/padinfo/menu/transforminfo.py
@@ -21,7 +21,8 @@ class TransformInfoMenu:
         dgcog = data['dgcog']
         user_config = data['user_config']
 
-        ims['query'] = str(ims['b_resolved_monster_id'])
+        # base is always first
+        ims['query'] = str(ims['resolved_monster_ids'][0])
         ims['resolved_monster_id'] = None
         id_view_state = await IdViewState.deserialize(dgcog, user_config, ims)
         id_control = TransformInfoMenu.id_control(id_view_state)
@@ -32,7 +33,8 @@ class TransformInfoMenu:
         dgcog = data['dgcog']
         user_config = data['user_config']
 
-        ims['query'] = str(ims['t_resolved_monster_id'])
+        # transform is always second
+        ims['query'] = str(ims['resolved_monster_ids'][1])
         ims['resolved_monster_id'] = None
         id_view_state = await IdViewState.deserialize(dgcog, user_config, ims)
         id_control = TransformInfoMenu.id_control(id_view_state)
@@ -69,7 +71,8 @@ class TransformInfoEmoji:
 
 class TransformInfoMenuPanes(MenuPanes):
     DATA = {
-        TransformInfoEmoji.home: (TransformInfoMenu.respond_with_overview, TransformInfoView.VIEW_TYPE),
+        TransformInfoEmoji.home: (TransformInfoMenu.respond_with_overview,
+                                  TransformInfoView.VIEW_TYPE),
         TransformInfoEmoji.down: (TransformInfoMenu.respond_with_base, IdView.VIEW_TYPE),
         TransformInfoEmoji.up: (TransformInfoMenu.respond_with_transform, IdView.VIEW_TYPE),
     }

--- a/padinfo/menu/transforminfo.py
+++ b/padinfo/menu/transforminfo.py
@@ -86,6 +86,7 @@ class TransformInfoEmoji:
     home = emoji_buttons['home']
     down = '\N{DOWN-POINTING RED TRIANGLE}'
     up = '\N{UP-POINTING RED TRIANGLE}'
+    one = char_to_emoji('1')
     two = char_to_emoji('2')
     three = char_to_emoji('3')
     four = char_to_emoji('4')
@@ -103,6 +104,7 @@ class TransformInfoMenuPanes(MenuPanes):
                                   TransformInfoView.VIEW_TYPE),
         TransformInfoEmoji.down: (TransformInfoMenu.respond_with_base, IdView.VIEW_TYPE),
         TransformInfoEmoji.up: (TransformInfoMenu.respond_with_transform, IdView.VIEW_TYPE),
+        TransformInfoEmoji.one: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
         TransformInfoEmoji.two: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
         TransformInfoEmoji.three: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
         TransformInfoEmoji.four: (TransformInfoMenu.respond_with_n, IdView.VIEW_TYPE),
@@ -115,8 +117,14 @@ class TransformInfoMenuPanes(MenuPanes):
     }
 
     @classmethod
-    def get_reaction_list(cls, number_of_further_transforms: int):
-        return cls.emoji_names()[:number_of_further_transforms]
+    def get_reaction_list(cls, number_of_monsters: int):
+        if number_of_monsters > 2:
+            cls.HIDDEN_EMOJIS = TransformInfoEmoji.up
+        else:
+            cls.HIDDEN_EMOJIS = TransformInfoEmoji.one
+
+        # add 1 for the home emoji
+        return cls.emoji_names()[:number_of_monsters + 1]
 
     @classmethod
     def get_n_from_reaction(cls, reaction):

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -765,8 +765,8 @@ class PadInfo(commands.Cog, IdTest):
         color = await self.get_user_embed_color(ctx)
         original_author_id = ctx.message.author.id
         acquire_raw = await TransformInfoViewState.query(dgcog, base_mon, transformed_mon)
-        # add 1 because the home emoji should be included
-        reaction_list = TransformInfoMenuPanes.get_reaction_list(len(monster_ids) + 1)
+        reaction_list = TransformInfoMenuPanes.get_reaction_list(len(monster_ids))
+
         state = TransformInfoViewState(original_author_id, TransformInfoMenu.MENU_TYPE, query,
                                        color, base_mon, transformed_mon, acquire_raw, monster_ids,
                                        reaction_list=reaction_list)

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -745,7 +745,7 @@ class PadInfo(commands.Cog, IdTest):
     async def transforminfo(self, ctx, *, query):
         """Show info about a transform card, including some helpful details about the base card."""
         dgcog = await self.get_dgcog()
-        base_mon, transformed_mon, reaction_ids = await perform_transforminfo_query(dgcog, query)
+        base_mon, transformed_mon, monster_ids = await perform_transforminfo_query(dgcog, query)
 
         if not base_mon:
             await self.send_id_failure_message(ctx, query)
@@ -761,7 +761,7 @@ class PadInfo(commands.Cog, IdTest):
         original_author_id = ctx.message.author.id
         acquire_raw = await TransformInfoViewState.query(dgcog, base_mon, transformed_mon)
         state = TransformInfoViewState(original_author_id, TransformInfoMenu.MENU_TYPE, query,
-                                       color, base_mon, transformed_mon, acquire_raw)
+                                       color, base_mon, transformed_mon, acquire_raw, monster_ids)
         menu = TransformInfoMenu.menu()
         await menu.create(ctx, state)
 

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -41,7 +41,7 @@ from padinfo.menu.menu_maps import type_to_panes, get_panes_class, get_menu
 from padinfo.menu.monster_list import MonsterListMenu, MonsterListMenuPanes, MonsterListEmoji
 from padinfo.menu.series_scroll import SeriesScrollMenuPanes, SeriesScrollMenu, SeriesScrollEmoji
 from padinfo.menu.simple_text import SimpleTextMenu
-from padinfo.menu.transforminfo import TransformInfoMenu
+from padinfo.menu.transforminfo import TransformInfoMenu, TransformInfoMenuPanes
 from padinfo.reaction_list import get_id_menu_initial_reaction_list
 from padinfo.view.closable_embed import ClosableEmbedViewState
 from padinfo.view.components.monster.header import MonsterHeader
@@ -168,7 +168,12 @@ class PadInfo(commands.Cog, IdTest):
         if not (await menu.should_respond(message, reaction, await self.get_reaction_filters(ims), member)):
             return
 
-        await menu.transition(message, deepcopy(ims), emoji_clicked, member, **(await self.get_menu_default_data(ims)))
+        data = await self.get_menu_default_data(ims)
+        data.update({
+            'reaction': emoji_clicked
+        })
+        
+        await menu.transition(message, deepcopy(ims), emoji_clicked, member, **data)
         await self.listener_respond_with_child(deepcopy(ims), message, emoji_clicked, member)
 
     @staticmethod
@@ -760,8 +765,11 @@ class PadInfo(commands.Cog, IdTest):
         color = await self.get_user_embed_color(ctx)
         original_author_id = ctx.message.author.id
         acquire_raw = await TransformInfoViewState.query(dgcog, base_mon, transformed_mon)
+        # add 1 because the home emoji should be included
+        reaction_list = TransformInfoMenuPanes.get_reaction_list(len(monster_ids) + 1)
         state = TransformInfoViewState(original_author_id, TransformInfoMenu.MENU_TYPE, query,
-                                       color, base_mon, transformed_mon, acquire_raw, monster_ids)
+                                       color, base_mon, transformed_mon, acquire_raw, monster_ids,
+                                       reaction_list=reaction_list)
         menu = TransformInfoMenu.menu()
         await menu.create(ctx, state)
 

--- a/padinfo/view/transforminfo.py
+++ b/padinfo/view/transforminfo.py
@@ -28,7 +28,7 @@ class TransformInfoViewState(ViewStateBase):
         self.color = color
         self.base_mon = base_mon
         self.transformed_mon = transformed_mon
-        self.acquire_raw = acquire_raw,
+        self.acquire_raw = acquire_raw
         self.monster_ids = monster_ids
 
     def serialize(self):

--- a/padinfo/view/transforminfo.py
+++ b/padinfo/view/transforminfo.py
@@ -23,18 +23,18 @@ TRANSFORM_EMOJI = '\N{UP-POINTING RED TRIANGLE}'
 
 class TransformInfoViewState(ViewStateBase):
     def __init__(self, original_author_id, menu_type, raw_query, color, base_mon, transformed_mon,
-                 acquire_raw):
+                 acquire_raw, monster_ids):
         super().__init__(original_author_id, menu_type, raw_query, extra_state=None)
         self.color = color
         self.base_mon = base_mon
         self.transformed_mon = transformed_mon
-        self.acquire_raw = acquire_raw
+        self.acquire_raw = acquire_raw,
+        self.monster_ids = monster_ids
 
     def serialize(self):
         ret = super().serialize()
         ret.update({
-            'b_resolved_monster_id': self.base_mon.monster_id,
-            't_resolved_monster_id': self.transformed_mon.monster_id
+            'resolved_monster_ids': self.monster_ids
         })
         return ret
 
@@ -43,8 +43,9 @@ class TransformInfoViewState(ViewStateBase):
         raw_query = ims['raw_query']
         original_author_id = ims['original_author_id']
         menu_type = ims['menu_type']
-        base_mon_id = ims['b_resolved_monster_id']
-        transformed_mon_id = ims['t_resolved_monster_id']
+        monster_ids = ims['resolved_monster_ids']
+        base_mon_id = monster_ids[0]
+        transformed_mon_id = monster_ids[1]
 
         base_mon = dgcog.get_monster(base_mon_id)
         transformed_mon = dgcog.get_monster(transformed_mon_id)
@@ -52,7 +53,7 @@ class TransformInfoViewState(ViewStateBase):
         acquire_raw = await TransformInfoViewState.query(dgcog, base_mon, transformed_mon)
 
         return TransformInfoViewState(original_author_id, menu_type, raw_query, user_config.color,
-                                      base_mon, transformed_mon, acquire_raw)
+                                      base_mon, transformed_mon, acquire_raw, monster_ids)
 
     @staticmethod
     async def query(dgcog, base_mon, transformed_mon):

--- a/padinfo/view/transforminfo.py
+++ b/padinfo/view/transforminfo.py
@@ -23,18 +23,20 @@ TRANSFORM_EMOJI = '\N{UP-POINTING RED TRIANGLE}'
 
 class TransformInfoViewState(ViewStateBase):
     def __init__(self, original_author_id, menu_type, raw_query, color, base_mon, transformed_mon,
-                 acquire_raw, monster_ids):
+                 acquire_raw, monster_ids, reaction_list):
         super().__init__(original_author_id, menu_type, raw_query, extra_state=None)
         self.color = color
         self.base_mon = base_mon
         self.transformed_mon = transformed_mon
         self.acquire_raw = acquire_raw
         self.monster_ids = monster_ids
+        self.reaction_list = reaction_list
 
     def serialize(self):
         ret = super().serialize()
         ret.update({
-            'resolved_monster_ids': self.monster_ids
+            'resolved_monster_ids': self.monster_ids,
+            'reaction_list': self.reaction_list
         })
         return ret
 
@@ -51,9 +53,11 @@ class TransformInfoViewState(ViewStateBase):
         transformed_mon = dgcog.get_monster(transformed_mon_id)
 
         acquire_raw = await TransformInfoViewState.query(dgcog, base_mon, transformed_mon)
+        reaction_list = ims['reaction_list']
 
         return TransformInfoViewState(original_author_id, menu_type, raw_query, user_config.color,
-                                      base_mon, transformed_mon, acquire_raw, monster_ids)
+                                      base_mon, transformed_mon, acquire_raw, monster_ids,
+                                      reaction_list=reaction_list)
 
     @staticmethod
     async def query(dgcog, base_mon, transformed_mon):


### PR DESCRIPTION
Finally resolves #764.

- Cards like Super-1 and Jiraiya now have reactions that can be clicked to show `id` of each of their transformations.
- Reactions are either 🔻 🔺 or 🔻 1️⃣ 2️⃣ etc. based on number of transformations.