### PR TITLE
Add awakeninghelp command

### DIFF
--- a/padinfo/menu/closable_embed.py
+++ b/padinfo/menu/closable_embed.py
@@ -2,11 +2,13 @@ from discordmenu.embed.control import EmbedControl
 from discordmenu.embed.menu import EmbedMenu
 
 from padinfo.menu.common import MenuPanes
+from padinfo.view.awakening_help import AwakeningHelpView
 from padinfo.view.closable_embed import ClosableEmbedViewState
 from padinfo.view.id_traceback import IdTracebackView
 
 view_types = {
-    IdTracebackView.VIEW_TYPE: IdTracebackView
+    AwakeningHelpView.VIEW_TYPE: AwakeningHelpView,
+    IdTracebackView.VIEW_TYPE: IdTracebackView,
 }
 
 

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -43,6 +43,7 @@ from padinfo.menu.series_scroll import SeriesScrollMenuPanes, SeriesScrollMenu, 
 from padinfo.menu.simple_text import SimpleTextMenu
 from padinfo.menu.transforminfo import TransformInfoMenu, TransformInfoMenuPanes
 from padinfo.reaction_list import get_id_menu_initial_reaction_list
+from padinfo.view.awakening_help import AwakeningHelpView, AwakeningHelpViewProps
 from padinfo.view.closable_embed import ClosableEmbedViewState
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.evos import EvosViewState
@@ -771,6 +772,24 @@ class PadInfo(commands.Cog, IdTest):
                                        color, base_mon, transformed_mon, acquire_raw, monster_ids,
                                        reaction_list=reaction_list)
         menu = TransformInfoMenu.menu()
+        await menu.create(ctx, state)
+
+    @commands.command(aliases=['awakehelp', 'awakeningshelp', 'awohelp', 'awokenhelp'])
+    async def awakeninghelp(self, ctx, *, query):
+        """Describe a monster's regular and super awakenings in detail."""
+        dgcog = await self.get_dgcog()
+        monster = await find_monster(dgcog, query)
+
+        if not monster:
+            await self.send_id_failure_message(ctx, query)
+            return
+
+        color = await self.get_user_embed_color(ctx)
+        original_author_id = ctx.message.author.id
+        menu = ClosableEmbedMenu.menu()
+        props = AwakeningHelpViewProps(monster=monster)
+        state = ClosableEmbedViewState(original_author_id, ClosableEmbedMenu.MENU_TYPE, query,
+                                       color, AwakeningHelpView.VIEW_TYPE, props)
         await menu.create(ctx, state)
 
     @commands.command()

--- a/padinfo/view/awakening_help.py
+++ b/padinfo/view/awakening_help.py
@@ -1,0 +1,68 @@
+from typing import TYPE_CHECKING
+
+from discordmenu.embed.base import Box
+from discordmenu.embed.components import EmbedMain, EmbedThumbnail, EmbedField
+from discordmenu.embed.text import Text
+from discordmenu.embed.view import EmbedView
+
+from padinfo.common.emoji_map import get_awakening_emoji
+from padinfo.common.external_links import puzzledragonx
+from padinfo.view.components.base import pad_info_footer_with_state
+from padinfo.view.components.monster.header import MonsterHeader
+from padinfo.view.components.monster.image import MonsterImage
+
+if TYPE_CHECKING:
+    from dadguide.models.monster_model import MonsterModel
+    from dadguide.models.awakening_model import AwakeningModel
+
+
+class AwakeningHelpViewProps:
+    def __init__(self, monster: "MonsterModel"):
+        self.monster = monster
+
+
+def _get_awakening_desc(awakening: "AwakeningModel"):
+    emoji_text = get_awakening_emoji(awakening.awoken_skill_id, awakening.name)
+    # TODO
+    desc = 'Awakening long description text here'
+    return Box(
+        Text(emoji_text),
+        Text(desc),
+        delimiter=' '
+    )
+
+
+def normal_awakenings(monster: "MonsterModel"):
+    normal_awakening_count = len(monster.awakenings) - monster.superawakening_count
+    awakening_descs = [_get_awakening_desc(a) for a in monster.awakenings[:normal_awakening_count]]
+    return Box(*awakening_descs)
+
+
+def super_awakenings(monster: "MonsterModel"):
+    normal_awakening_count = len(monster.awakenings) - monster.superawakening_count
+    awakening_descs = [_get_awakening_desc(a) for a in monster.awakenings[normal_awakening_count:]]
+    return Box(*awakening_descs) if len(awakening_descs) > 0 else None
+
+
+class AwakeningHelpView:
+    VIEW_TYPE = 'AwakeningHelp'
+
+    @staticmethod
+    def embed(state, props: AwakeningHelpViewProps):
+        monster = props.monster
+
+        fields = [
+            EmbedField('Normal Awakenings', normal_awakenings(monster)),
+            EmbedField('Super Awakenings', super_awakenings(monster))
+        ]
+
+        return EmbedView(
+            EmbedMain(
+                color=state.color,
+                title=MonsterHeader.long_v2(monster).to_markdown(),
+                url=puzzledragonx(monster)
+            ),
+            embed_thumbnail=EmbedThumbnail(MonsterImage.icon(monster)),
+            embed_footer=pad_info_footer_with_state(state),
+            embed_fields=fields
+        )

--- a/padinfo/view/awakening_help.py
+++ b/padinfo/view/awakening_help.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from discordmenu.embed.base import Box
-from discordmenu.embed.components import EmbedMain, EmbedThumbnail, EmbedField
+from discordmenu.embed.components import EmbedMain, EmbedField, EmbedAuthor
 from discordmenu.embed.text import Text
 from discordmenu.embed.view import EmbedView
 
@@ -57,12 +57,12 @@ class AwakeningHelpView:
         ]
 
         return EmbedView(
-            EmbedMain(
-                color=state.color,
-                title=MonsterHeader.long_v2(monster).to_markdown(),
-                url=puzzledragonx(monster)
+            EmbedMain(color=state.color),
+            embed_author=EmbedAuthor(
+                MonsterHeader.long_v2(monster).to_markdown(),
+                puzzledragonx(monster),
+                MonsterImage.icon(monster)
             ),
-            embed_thumbnail=EmbedThumbnail(MonsterImage.icon(monster)),
             embed_footer=pad_info_footer_with_state(state),
             embed_fields=fields
         )

--- a/padinfo/view/awakening_help.py
+++ b/padinfo/view/awakening_help.py
@@ -21,10 +21,9 @@ class AwakeningHelpViewProps:
         self.monster = monster
 
 
-def _get_awakening_desc(awakening: "AwakeningModel"):
+def _get_awakening_desc(index: int, awakening: "AwakeningModel"):
     emoji_text = get_awakening_emoji(awakening.awoken_skill_id, awakening.name)
-    # TODO
-    desc = 'Awakening long description text here'
+    desc = awakening.awoken_skill.desc_en
     return Box(
         Text(emoji_text),
         Text(desc),
@@ -34,13 +33,15 @@ def _get_awakening_desc(awakening: "AwakeningModel"):
 
 def normal_awakenings(monster: "MonsterModel"):
     normal_awakening_count = len(monster.awakenings) - monster.superawakening_count
-    awakening_descs = [_get_awakening_desc(a) for a in monster.awakenings[:normal_awakening_count]]
+    normal_awakenings = monster.awakenings[:normal_awakening_count]
+    awakening_descs = [_get_awakening_desc(i, awake) for i, awake in enumerate(normal_awakenings)]
     return Box(*awakening_descs)
 
 
 def super_awakenings(monster: "MonsterModel"):
     normal_awakening_count = len(monster.awakenings) - monster.superawakening_count
-    awakening_descs = [_get_awakening_desc(a) for a in monster.awakenings[normal_awakening_count:]]
+    super_awakenings = monster.awakenings[normal_awakening_count:]
+    awakening_descs = [_get_awakening_desc(i, awake) for i, awake in enumerate(super_awakenings)]
     return Box(*awakening_descs) if len(awakening_descs) > 0 else Box()
 
 
@@ -67,5 +68,5 @@ class AwakeningHelpView:
                 MonsterImage.icon(monster)
             ),
             embed_footer=pad_info_footer_with_state(state),
-            embed_fields=fields if monster.awakenings else None
+            embed_fields=fields
         )

--- a/padinfo/view/awakening_help.py
+++ b/padinfo/view/awakening_help.py
@@ -41,7 +41,7 @@ def normal_awakenings(monster: "MonsterModel"):
 def super_awakenings(monster: "MonsterModel"):
     normal_awakening_count = len(monster.awakenings) - monster.superawakening_count
     awakening_descs = [_get_awakening_desc(a) for a in monster.awakenings[normal_awakening_count:]]
-    return Box(*awakening_descs) if len(awakening_descs) > 0 else None
+    return Box(*awakening_descs) if len(awakening_descs) > 0 else Box()
 
 
 class AwakeningHelpView:

--- a/padinfo/view/awakening_help.py
+++ b/padinfo/view/awakening_help.py
@@ -57,12 +57,15 @@ class AwakeningHelpView:
         ]
 
         return EmbedView(
-            EmbedMain(color=state.color),
+            EmbedMain(
+                color=state.color,
+                description='This monster has no awakenings.' if not monster.awakenings else ''
+            ),
             embed_author=EmbedAuthor(
                 MonsterHeader.long_v2(monster).to_markdown(),
                 puzzledragonx(monster),
                 MonsterImage.icon(monster)
             ),
             embed_footer=pad_info_footer_with_state(state),
-            embed_fields=fields
+            embed_fields=fields if monster.awakenings else None
         )

--- a/padinfo/view/awakening_help.py
+++ b/padinfo/view/awakening_help.py
@@ -23,7 +23,7 @@ class AwakeningHelpViewProps:
         self.monster = monster
 
 
-def _get_awakening_desc(index: int, awakening: "AwakeningModel"):
+def _get_long_desc(awakening: "AwakeningModel"):
     emoji_text = get_awakening_emoji(awakening.awoken_skill_id, awakening.name)
     desc = awakening.awoken_skill.desc_en
     return Box(
@@ -48,7 +48,7 @@ def _get_all_awakening_descs(awakening_list):
     for index, awakening in enumerate(awakening_list):
         if awakening.name not in appearances:
             appearances[awakening.name] = index
-            awakening_descs.append(_get_awakening_desc(index, awakening))
+            awakening_descs.append(_get_long_desc(awakening))
         else:
             awakening_descs.append(_get_short_desc(appearances[awakening.name], awakening))
 


### PR DESCRIPTION
Resolves #324. Relates to #326 and #914.

Shows each of a monster's awakenings with an emoji and a description. The description is long if this is the first appearance of the awakening in its group (normal or super), otherwise the description refers back to the first appearance of the awakening.