### PR TITLE
Guarantee a pantheon tab by filtering if needed

### DIFF
--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -471,7 +471,8 @@ class PadInfo(commands.Cog, IdTest):
 
         pantheon_list, series_name, base_monster = await PantheonViewState.query(dgcog, monster)
         if pantheon_list is None:
-            await ctx.send(inline('Too many monsters in this series to display'))
+            await ctx.send('Unable to find a pantheon for the result of your query,'
+                           + ' [{}] {}.'.format(monster.monster_id, monster.name_en))
             return
         alt_monsters = PantheonViewState.get_alt_monsters(dgcog, monster)
         full_reaction_list = [emoji_cache.get_by_name(e) for e in IdMenuPanes.emoji_names()]

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -469,7 +469,7 @@ class PadInfo(commands.Cog, IdTest):
             await self.send_id_failure_message(ctx, query)
             return
 
-        pantheon_list, series_name = await PantheonViewState.query(dgcog, monster)
+        pantheon_list, series_name, base_monster = await PantheonViewState.query(dgcog, monster)
         if pantheon_list is None:
             await ctx.send(inline('Too many monsters in this series to display'))
             return
@@ -478,7 +478,7 @@ class PadInfo(commands.Cog, IdTest):
         initial_reaction_list = await get_id_menu_initial_reaction_list(ctx, dgcog, monster, full_reaction_list)
 
         state = PantheonViewState(original_author_id, IdMenu.MENU_TYPE, raw_query, query, color,
-                                  monster, alt_monsters, pantheon_list, series_name,
+                                  monster, alt_monsters, pantheon_list, series_name, base_monster,
                                   reaction_list=initial_reaction_list,
                                   use_evo_scroll=settings.checkEvoID(ctx.author.id))
         menu = IdMenu.menu(initial_control=IdMenu.pantheon_control)

--- a/padinfo/reaction_list.py
+++ b/padinfo/reaction_list.py
@@ -24,7 +24,7 @@ async def get_id_menu_initial_reaction_list(ctx, dgcog, monster: "MonsterModel",
         full_reaction_list.remove(IdMenuEmoji.left)
         full_reaction_list.remove(IdMenuEmoji.right)
         full_reaction_list.remove(IdMenuEmoji.evos)
-    pantheon_list, _ = await PantheonViewState.query(dgcog, monster)
+    pantheon_list, _, _ = await PantheonViewState.query(dgcog, monster)
     if pantheon_list is None:
         full_reaction_list.remove(IdMenuEmoji.pantheon)
     mats, usedin, gemid, _, skillups, _, _, _ = await MaterialsViewState.query(dgcog, monster)

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -69,6 +69,14 @@ class PantheonViewState(ViewStateBaseId):
 
     @classmethod
     async def query(cls, dgcog, monster):
+        # filtering rules:
+        # 1. don't show monsters that only have mat types (or show only mats if monster is a mat)
+        # 2. if still too many, show only monsters with the same base rarity
+        # 3. if still too many, show only monsters with the same base main attribute (any monster
+        #        without a main attribute is compared using its subattribute)
+        # 4. if still too many, show only monsters that match both base attributes
+        # 5. if still too many, truncate (and probably redefine pantheon)
+
         db_context = dgcog.database
         series_name = monster.series.name_en
         full_pantheon = db_context.get_monsters_by_series(monster.series_id)

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -90,7 +90,7 @@ class PantheonViewState(ViewStateBaseId):
         base_mon = db_context.graph.get_base_monster(monster)
 
         base_list = [m for m in full_pantheon if db_context.graph.monster_is_base(m)]
-        if len(base_list) > 0 and len(base_list) <= MAX_MONS_TO_SHOW:
+        if 0 < len(base_list) <= MAX_MONS_TO_SHOW:
             return base_list, series_name, base_mon
 
         # if monster has only mat types, show only mats, otherwise show everything else
@@ -100,14 +100,14 @@ class PantheonViewState(ViewStateBaseId):
             type_list = [m for m in base_list if all(t.name in MAT_TYPES for t in m.types)]
         else:
             type_list = [m for m in base_list if any(t.name not in MAT_TYPES for t in m.types)]
-        if len(type_list) > 0 and len(type_list) <= MAX_MONS_TO_SHOW:
+        if 0 < len(type_list) <= MAX_MONS_TO_SHOW:
             return type_list, series_name, base_mon
 
         filters = []
 
         rarity_list = [m for m in type_list if m.rarity == base_mon.rarity]
         filters.append('{}*'.format(base_mon.rarity))
-        if len(rarity_list) > 0 and len(rarity_list) <= MAX_MONS_TO_SHOW:
+        if 0 < len(rarity_list) <= MAX_MONS_TO_SHOW:
             return rarity_list, cls.make_series_name(series_name, filters), base_mon
 
         main_att = base_mon.attr1
@@ -127,7 +127,7 @@ class PantheonViewState(ViewStateBaseId):
             main_att_list = [m for m in rarity_list if m.attr1.name == main_att.name
                                                        or (m.attr1.name == NIL_ATT
                                                            and m.attr2.name == main_att.name)]
-        if len(main_att_list) > 0 and len(main_att_list) <= MAX_MONS_TO_SHOW:
+        if 0 < len(main_att_list) <= MAX_MONS_TO_SHOW:
             # append after check this time, because if we go to subatt we only want one emoji
             filters.append(att_emoji)
             return main_att_list, cls.make_series_name(series_name, filters), base_mon
@@ -135,7 +135,7 @@ class PantheonViewState(ViewStateBaseId):
         sub_att_list = [m for m in main_att_list if m.attr1.name == main_att.name
                                                     and m.attr2.name == sub_att.name]
         filters.append(get_attribute_emoji_by_monster(base_mon))
-        if len(sub_att_list) > 0 and len(sub_att_list) <= MAX_MONS_TO_SHOW:
+        if 0 < len(sub_att_list) <= MAX_MONS_TO_SHOW:
             return sub_att_list, cls.make_series_name(series_name, filters), base_mon
 
         # if we've managed to get here, just cut it off

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -19,6 +19,12 @@ if TYPE_CHECKING:
 MAX_MONS_TO_SHOW = 20
 MAT_TYPES = [0, 12, 14, 15]
 NO_ATT = 6
+CRITERIA = {
+    'typed': 'by mat/non-mat type',
+    'rarity': 'by mat/non-mat and rarity',
+    'main_att': 'by mat/non-mat, rarity, and main att',
+    'both_atts': 'by mat/non-mat, rarity, and attributes'
+}
 
 
 class PantheonViewState(ViewStateBaseId):
@@ -86,13 +92,13 @@ class PantheonViewState(ViewStateBaseId):
             typed_list = list(filter(lambda x: any(t.value not in MAT_TYPES for t in x.types),
                                      base_list))
         if len(typed_list) > 0 and len(typed_list) < MAX_MONS_TO_SHOW:
-            return typed_list, series_name
+            return typed_list, '{} ({})'.format(series_name, CRITERIA['typed'])
 
         base_mon = db_context.graph.get_base_monster(monster)
 
         rarity_list = list(filter(lambda x: x.rarity == base_mon.rarity, typed_list))
         if len(rarity_list) > 0 and len(rarity_list) < MAX_MONS_TO_SHOW:
-            return rarity_list, series_name
+            return rarity_list, '{} ({})'.format(series_name, CRITERIA['rarity'])
 
         main_att = base_mon.attr1.value
         sub_att = base_mon.attr2.value
@@ -106,16 +112,16 @@ class PantheonViewState(ViewStateBaseId):
         else:
             main_att_list = list(filter(lambda x: x.attr1.value == main_att, rarity_list))
         if len(main_att_list) > 0 and len(main_att_list) < MAX_MONS_TO_SHOW:
-            return main_att_list, series_name
+            return main_att_list, '{} ({})'.format(series_name, CRITERIA['main_att'])
 
         sub_att_list = list(filter(lambda x: x.attr2.value == sub_att, main_att_list))
         if len(sub_att_list) > 0 and len(sub_att_list) < MAX_MONS_TO_SHOW:
-            return sub_att_list, series_name
+            return sub_att_list, '{} ({})'.format(series_name, CRITERIA['both_atts'])
 
         # if we've managed to get here, just cut it off
         pantheon_list = sub_att_list[:MAX_MONS_TO_SHOW]
 
-        return pantheon_list, series_name
+        return pantheon_list, '{} ({})'.format(series_name, 'too many, truncated')
 
 
 class PantheonView:

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -110,12 +110,15 @@ class PantheonViewState(ViewStateBaseId):
                                                            and m.attr2.value == sub_att.value)]
         else:
             att_emoji = get_attribute_emoji_by_enum(main_att)
-            main_att_list = [m for m in rarity_list if m.attr1.value == main_att.value]
+            main_att_list = [m for m in rarity_list if m.attr1.value == main_att.value
+                                                       or (m.attr1.value == NO_ATT
+                                                           and m.attr2.value == main_att.value)]
         # don't concatenate filter this time, because if we go to subatt we only want one emoji
         if len(main_att_list) > 0 and len(main_att_list) < MAX_MONS_TO_SHOW:
             return main_att_list, series_name + filters + ' {}]'.format(att_emoji), base_mon
 
-        sub_att_list = [m for m in main_att_list if m.attr2.value == sub_att.value]
+        sub_att_list = [m for m in main_att_list if m.attr1.value == main_att.value
+                                                    and m.attr2.value == sub_att.value]
         filters += ' {}'.format(get_attribute_emoji_by_monster(base_mon))
         if len(sub_att_list) > 0 and len(sub_att_list) < MAX_MONS_TO_SHOW:
             return sub_att_list, series_name + filters + ']', base_mon

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -77,7 +77,7 @@ class PantheonViewState(ViewStateBaseId):
 
         base_mon = db_context.graph.get_base_monster(monster)
 
-        base_list = list(filter(lambda x: db_context.graph.monster_is_base(x), full_pantheon))
+        base_list = [m for m in full_pantheon if db_context.graph.monster_is_base(m)]
         if len(base_list) > 0 and len(base_list) < MAX_MONS_TO_SHOW:
             return base_list, series_name, base_mon
 
@@ -85,17 +85,15 @@ class PantheonViewState(ViewStateBaseId):
         type_list = []
         if all(t.value in MAT_TYPES for t in monster.types):
             series_name += ' (Mat)'
-            type_list = list(filter(lambda x: all(t.value in MAT_TYPES for t in x.types), 
-                                    base_list))
+            type_list = [m for m in base_list if all(t.value in MAT_TYPES for t in m.types)]
         else:
-            type_list = list(filter(lambda x: any(t.value not in MAT_TYPES for t in x.types),
-                                    base_list))
+            type_list = [m for m in base_list if any(t.value not in MAT_TYPES for t in m.types)]
         if len(type_list) > 0 and len(type_list) < MAX_MONS_TO_SHOW:
             return type_list, series_name, base_mon
 
         filters = ' [Filters: '
 
-        rarity_list = list(filter(lambda x: x.rarity == base_mon.rarity, type_list))
+        rarity_list = [m for m in type_list if m.rarity == base_mon.rarity]
         filters += '{}*'.format(base_mon.rarity)
         if len(rarity_list) > 0 and len(rarity_list) < MAX_MONS_TO_SHOW:
             return rarity_list, series_name + filters + ']', base_mon
@@ -107,18 +105,17 @@ class PantheonViewState(ViewStateBaseId):
         att_emoji = None
         if main_att.value == NO_ATT:
             att_emoji = get_attribute_emoji_by_enum(sub_att)
-            main_att_list = list(filter(lambda x: x.attr1.value == sub_att.value
-                                                  or (x.attr1.value == NO_ATT
-                                                      and x.attr2.value == sub_att.value),
-                                        rarity_list))
+            main_att_list = [m for m in rarity_list if m.attr1.value == sub_att.value
+                                                       or (m.attr1.value == NO_ATT
+                                                           and m.attr2.value == sub_att.value)]
         else:
             att_emoji = get_attribute_emoji_by_enum(main_att)
-            main_att_list = list(filter(lambda x: x.attr1.value == main_att.value, rarity_list))
+            main_att_list = [m for m in rarity_list if m.attr1.value == main_att.value]
         # don't concatenate filter this time, because if we go to subatt we only want one emoji
         if len(main_att_list) > 0 and len(main_att_list) < MAX_MONS_TO_SHOW:
             return main_att_list, series_name + filters + ' {}]'.format(att_emoji), base_mon
 
-        sub_att_list = list(filter(lambda x: x.attr2.value == sub_att.value, main_att_list))
+        sub_att_list = [m for m in main_att_list if m.attr2.value == sub_att.value]
         filters += ' {}'.format(get_attribute_emoji_by_monster(base_mon))
         if len(sub_att_list) > 0 and len(sub_att_list) < MAX_MONS_TO_SHOW:
             return sub_att_list, series_name + filters + ']', base_mon

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -145,23 +145,23 @@ class PantheonViewState(ViewStateBaseId):
         return pantheon_list, cls.make_series_name(series_name, filters), base_mon
 
 
+def _pantheon_lines(monsters, base_monster):
+    if not len(monsters):
+        return []
+    return [
+        MonsterHeader.short_with_emoji(mon, link=mon.monster_id != base_monster.monster_id)
+        for mon in sorted(monsters, key=lambda x: int(x.monster_id))
+    ]
+
+
 class PantheonView:
     VIEW_TYPE = 'Pantheon'
-
-    @staticmethod
-    def _pantheon_lines(monsters, base_monster):
-        if not len(monsters):
-            return []
-        return [
-            MonsterHeader.short_with_emoji(mon, link=mon.monster_id != base_monster.monster_id)
-            for mon in sorted(monsters, key=lambda x: int(x.monster_id))
-        ]
 
     @staticmethod
     def embed(state: PantheonViewState):
         fields = [EmbedField(
             'Pantheon: {}'.format(state.series_name),
-            Box(*PantheonView._pantheon_lines(state.pantheon_list, state.base_monster))
+            Box(*_pantheon_lines(state.pantheon_list, state.base_monster))
         ),
             evos_embed_field(state)]
 

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 MAX_MONS_TO_SHOW = 20
 MATS_TYPES = [0, 12, 14, 15]
+NO_ATT = 6
 
 
 class PantheonViewState(ViewStateBaseId):
@@ -94,11 +95,21 @@ class PantheonViewState(ViewStateBaseId):
         if len(rarity_list) > 0 and len(rarity_list) < MAX_MONS_TO_SHOW:
             return rarity_list, series_name
 
-        main_att_list = list(filter(lambda x: x.attr1.value == base_mon.attr1.value, rarity_list))
+        main_att = base_mon.attr1.value
+        sub_att = base_mon.attr2.value
+
+        main_att_list = []
+        if main_att == NO_ATT:
+            main_att_list = list(filter(lambda x: x.attr1.value == sub_att
+                                                  or (x.attr1.value == NO_ATT
+                                                      and x.attr2.value == sub_att),
+                                        rarity_list))
+        else:
+            main_att_list = list(filter(lambda x: x.attr1.value == main_att, rarity_list))
         if len(main_att_list) > 0 and len(main_att_list) < MAX_MONS_TO_SHOW:
             return main_att_list, series_name
 
-        sub_att_list = list(filter(lambda x: x.attr2.value == base_mon.attr2.value, main_att_list))
+        sub_att_list = list(filter(lambda x: x.attr2.value == sub_att, main_att_list))
         if len(sub_att_list) > 0 and len(sub_att_list) < MAX_MONS_TO_SHOW:
             return sub_att_list, series_name
 

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
 MAX_MONS_TO_SHOW = 20
-MAT_TYPES = [0, 12, 14, 15]
-NO_ATT = 6
+MAT_TYPES = ['Evolve', 'Awoken', 'Enhance', 'Vendor']
+NO_ATT = 'Nil'
 
 
 class PantheonViewState(ViewStateBaseId):
@@ -91,11 +91,11 @@ class PantheonViewState(ViewStateBaseId):
 
         # if monster has only mat types, show only mats, otherwise show everything else
         type_list = []
-        if all(t.value in MAT_TYPES for t in monster.types):
+        if all(t.name in MAT_TYPES for t in monster.types):
             series_name += ' (Mat)'
-            type_list = [m for m in base_list if all(t.value in MAT_TYPES for t in m.types)]
+            type_list = [m for m in base_list if all(t.name in MAT_TYPES for t in m.types)]
         else:
-            type_list = [m for m in base_list if any(t.value not in MAT_TYPES for t in m.types)]
+            type_list = [m for m in base_list if any(t.name not in MAT_TYPES for t in m.types)]
         if len(type_list) > 0 and len(type_list) < MAX_MONS_TO_SHOW:
             return type_list, series_name, base_mon
 
@@ -111,22 +111,22 @@ class PantheonViewState(ViewStateBaseId):
 
         main_att_list = []
         att_emoji = None
-        if main_att.value == NO_ATT:
+        if main_att.name == NO_ATT:
             att_emoji = get_attribute_emoji_by_enum(sub_att)
-            main_att_list = [m for m in rarity_list if m.attr1.value == sub_att.value
-                                                       or (m.attr1.value == NO_ATT
-                                                           and m.attr2.value == sub_att.value)]
+            main_att_list = [m for m in rarity_list if m.attr1.name == sub_att.name
+                                                       or (m.attr1.name == NO_ATT
+                                                           and m.attr2.name == sub_att.name)]
         else:
             att_emoji = get_attribute_emoji_by_enum(main_att)
-            main_att_list = [m for m in rarity_list if m.attr1.value == main_att.value
-                                                       or (m.attr1.value == NO_ATT
-                                                           and m.attr2.value == main_att.value)]
+            main_att_list = [m for m in rarity_list if m.attr1.name == main_att.name
+                                                       or (m.attr1.name == NO_ATT
+                                                           and m.attr2.name == main_att.name)]
         # don't concatenate filter this time, because if we go to subatt we only want one emoji
         if len(main_att_list) > 0 and len(main_att_list) < MAX_MONS_TO_SHOW:
             return main_att_list, series_name + filters + ' {}]'.format(att_emoji), base_mon
 
-        sub_att_list = [m for m in main_att_list if m.attr1.value == main_att.value
-                                                    and m.attr2.value == sub_att.value]
+        sub_att_list = [m for m in main_att_list if m.attr1.name == main_att.name
+                                                    and m.attr2.name == sub_att.name]
         filters += ' {}'.format(get_attribute_emoji_by_monster(base_mon))
         if len(sub_att_list) > 0 and len(sub_att_list) < MAX_MONS_TO_SHOW:
             return sub_att_list, series_name + filters + ']', base_mon

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -90,7 +90,7 @@ class PantheonViewState(ViewStateBaseId):
         base_mon = db_context.graph.get_base_monster(monster)
 
         base_list = [m for m in full_pantheon if db_context.graph.monster_is_base(m)]
-        if len(base_list) > 0 and len(base_list) < MAX_MONS_TO_SHOW:
+        if len(base_list) > 0 and len(base_list) <= MAX_MONS_TO_SHOW:
             return base_list, series_name, base_mon
 
         # if monster has only mat types, show only mats, otherwise show everything else
@@ -100,14 +100,14 @@ class PantheonViewState(ViewStateBaseId):
             type_list = [m for m in base_list if all(t.name in MAT_TYPES for t in m.types)]
         else:
             type_list = [m for m in base_list if any(t.name not in MAT_TYPES for t in m.types)]
-        if len(type_list) > 0 and len(type_list) < MAX_MONS_TO_SHOW:
+        if len(type_list) > 0 and len(type_list) <= MAX_MONS_TO_SHOW:
             return type_list, series_name, base_mon
 
         filters = []
 
         rarity_list = [m for m in type_list if m.rarity == base_mon.rarity]
         filters.append('{}*'.format(base_mon.rarity))
-        if len(rarity_list) > 0 and len(rarity_list) < MAX_MONS_TO_SHOW:
+        if len(rarity_list) > 0 and len(rarity_list) <= MAX_MONS_TO_SHOW:
             return rarity_list, cls.make_series_name(series_name, filters), base_mon
 
         main_att = base_mon.attr1
@@ -127,7 +127,7 @@ class PantheonViewState(ViewStateBaseId):
             main_att_list = [m for m in rarity_list if m.attr1.name == main_att.name
                                                        or (m.attr1.name == NIL_ATT
                                                            and m.attr2.name == main_att.name)]
-        if len(main_att_list) > 0 and len(main_att_list) < MAX_MONS_TO_SHOW:
+        if len(main_att_list) > 0 and len(main_att_list) <= MAX_MONS_TO_SHOW:
             # append after check this time, because if we go to subatt we only want one emoji
             filters.append(att_emoji)
             return main_att_list, cls.make_series_name(series_name, filters), base_mon
@@ -135,7 +135,7 @@ class PantheonViewState(ViewStateBaseId):
         sub_att_list = [m for m in main_att_list if m.attr1.name == main_att.name
                                                     and m.attr2.name == sub_att.name]
         filters.append(get_attribute_emoji_by_monster(base_mon))
-        if len(sub_att_list) > 0 and len(sub_att_list) < MAX_MONS_TO_SHOW:
+        if len(sub_att_list) > 0 and len(sub_att_list) <= MAX_MONS_TO_SHOW:
             return sub_att_list, cls.make_series_name(series_name, filters), base_mon
 
         # if we've managed to get here, just cut it off

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -88,16 +88,17 @@ class PantheonViewState(ViewStateBaseId):
         if len(typed_list) > 0 and len(typed_list) < MAX_MONS_TO_SHOW:
             return typed_list, series_name
 
-        monster_base_rarity = db_context.graph.get_base_monster(monster).rarity
-        rarity_list = list(filter(lambda x: x.rarity == monster_base_rarity, typed_list))
+        base_mon = db_context.graph.get_base_monster(monster)
+
+        rarity_list = list(filter(lambda x: x.rarity == base_mon.rarity, typed_list))
         if len(rarity_list) > 0 and len(rarity_list) < MAX_MONS_TO_SHOW:
             return rarity_list, series_name
 
-        main_att_list = list(filter(lambda x: x.attr1.value == monster.attr1.value, rarity_list))
+        main_att_list = list(filter(lambda x: x.attr1.value == base_mon.attr1.value, rarity_list))
         if len(main_att_list) > 0 and len(main_att_list) < MAX_MONS_TO_SHOW:
             return main_att_list, series_name
 
-        sub_att_list = list(filter(lambda x: x.attr2.value == monster.attr2.value, main_att_list))
+        sub_att_list = list(filter(lambda x: x.attr2.value == base_mon.attr2.value, main_att_list))
         if len(sub_att_list) > 0 and len(sub_att_list) < MAX_MONS_TO_SHOW:
             return sub_att_list, series_name
 

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
 MAX_MONS_TO_SHOW = 20
-MATS_TYPES = [0, 12, 14, 15]
+MAT_TYPES = [0, 12, 14, 15]
 NO_ATT = 6
 
 
@@ -77,14 +77,13 @@ class PantheonViewState(ViewStateBaseId):
         if len(base_list) > 0 and len(base_list) < MAX_MONS_TO_SHOW:
             return base_list, series_name
 
-        # exclude mats if monster is a mat, otherwise show only mats
-        # TODO: filter mats by type
+        # exclude mats if monster has no mat types, otherwise show only mats
         typed_list = []
-        if any(t.value in MATS_TYPES for t in monster.types):
-            typed_list = list(filter(lambda x: any(t.value in MATS_TYPES for t in x.types), 
+        if all(t.value in MAT_TYPES for t in monster.types):
+            typed_list = list(filter(lambda x: all(t.value in MAT_TYPES for t in x.types), 
                                      base_list))
         else:
-            typed_list = list(filter(lambda x: all(t.value not in MATS_TYPES for t in x.types),
+            typed_list = list(filter(lambda x: any(t.value not in MAT_TYPES for t in x.types),
                                      base_list))
         if len(typed_list) > 0 and len(typed_list) < MAX_MONS_TO_SHOW:
             return typed_list, series_name

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -16,6 +16,8 @@ from padinfo.view.id import evos_embed_field
 if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
+MAX_MONS_TO_SHOW = 20
+
 
 class PantheonViewState(ViewStateBaseId):
     def __init__(self, original_author_id, menu_type, raw_query, query, color, monster: "MonsterModel", alt_monsters,
@@ -68,7 +70,7 @@ class PantheonViewState(ViewStateBaseId):
         if not full_pantheon:
             return None, None
         pantheon_list = list(filter(lambda x: db_context.graph.monster_is_base(x), full_pantheon))
-        if len(pantheon_list) == 0 or len(pantheon_list) > 20:
+        if len(pantheon_list) == 0 or len(pantheon_list) > MAX_MONS_TO_SHOW:
             return None, None
 
         series_name = monster.series.name_en

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -20,7 +20,7 @@ MAX_MONS_TO_SHOW = 20
 MAT_TYPES = [0, 12, 14, 15]
 NO_ATT = 6
 CRITERIA = {
-    'typed': 'by mat/non-mat type',
+    'type': 'by mat/non-mat type',
     'rarity': 'by mat/non-mat and rarity',
     'main_att': 'by mat/non-mat, rarity, and main att',
     'both_atts': 'by mat/non-mat, rarity, and attributes'
@@ -83,20 +83,20 @@ class PantheonViewState(ViewStateBaseId):
         if len(base_list) > 0 and len(base_list) < MAX_MONS_TO_SHOW:
             return base_list, series_name
 
-        # exclude mats if monster has no mat types, otherwise show only mats
-        typed_list = []
+        # if monster has only mat types, show only mats, otherwise show everything non-mat
+        type_list = []
         if all(t.value in MAT_TYPES for t in monster.types):
-            typed_list = list(filter(lambda x: all(t.value in MAT_TYPES for t in x.types), 
-                                     base_list))
+            type_list = list(filter(lambda x: all(t.value in MAT_TYPES for t in x.types), 
+                                    base_list))
         else:
-            typed_list = list(filter(lambda x: any(t.value not in MAT_TYPES for t in x.types),
-                                     base_list))
-        if len(typed_list) > 0 and len(typed_list) < MAX_MONS_TO_SHOW:
-            return typed_list, '{} ({})'.format(series_name, CRITERIA['typed'])
+            type_list = list(filter(lambda x: any(t.value not in MAT_TYPES for t in x.types),
+                                    base_list))
+        if len(type_list) > 0 and len(type_list) < MAX_MONS_TO_SHOW:
+            return type_list, '{} ({})'.format(series_name, CRITERIA['type'])
 
         base_mon = db_context.graph.get_base_monster(monster)
 
-        rarity_list = list(filter(lambda x: x.rarity == base_mon.rarity, typed_list))
+        rarity_list = list(filter(lambda x: x.rarity == base_mon.rarity, type_list))
         if len(rarity_list) > 0 and len(rarity_list) < MAX_MONS_TO_SHOW:
             return rarity_list, '{} ({})'.format(series_name, CRITERIA['rarity'])
 

--- a/padinfo/view/pantheon.py
+++ b/padinfo/view/pantheon.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 MAX_MONS_TO_SHOW = 20
 MAT_TYPES = ['Evolve', 'Awoken', 'Enhance', 'Vendor']
-NO_ATT = 'Nil'
+NIL_ATT = 'Nil'
 
 
 class PantheonViewState(ViewStateBaseId):
@@ -73,7 +73,7 @@ class PantheonViewState(ViewStateBaseId):
         # 1. don't show monsters that only have mat types (or show only mats if monster is a mat)
         # 2. if still too many, show only monsters with the same base rarity
         # 3. if still too many, show only monsters with the same base main attribute (any monster
-        #        without a main attribute is compared using its subattribute)
+        #        with nil main attribute is compared using its subattribute)
         # 4. if still too many, show only monsters that match both base attributes
         # 5. if still too many, truncate (and probably redefine pantheon)
 
@@ -109,17 +109,19 @@ class PantheonViewState(ViewStateBaseId):
         main_att = base_mon.attr1
         sub_att = base_mon.attr2
 
+        # if the monster has nil main attribute, do comparisons using its subattribute
+        # if any monster in the list has nil main attribute, also compare using its subattribute
         main_att_list = []
         att_emoji = None
-        if main_att.name == NO_ATT:
+        if main_att.name == NIL_ATT:
             att_emoji = get_attribute_emoji_by_enum(sub_att)
             main_att_list = [m for m in rarity_list if m.attr1.name == sub_att.name
-                                                       or (m.attr1.name == NO_ATT
+                                                       or (m.attr1.name == NIL_ATT
                                                            and m.attr2.name == sub_att.name)]
         else:
             att_emoji = get_attribute_emoji_by_enum(main_att)
             main_att_list = [m for m in rarity_list if m.attr1.name == main_att.name
-                                                       or (m.attr1.name == NO_ATT
+                                                       or (m.attr1.name == NIL_ATT
                                                            and m.attr2.name == main_att.name)]
         # don't concatenate filter this time, because if we go to subatt we only want one emoji
         if len(main_att_list) > 0 and len(main_att_list) < MAX_MONS_TO_SHOW:


### PR DESCRIPTION
Resolves #813.

Filters pantheons so that a manageable number are returned for any monster and shows the filtering criteria. Also indicates the current monster in the pantheon list.