### PR TITLE
Add additional info to ^buttoninfo

### DIFF
--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -16,7 +16,8 @@ Subattr: {}
 Total:   {}
 
 --------------
-{}{}
+{}
+{}
 """
 
 TEAM_BUTTON_FORMAT = "As {} base ({}x {}): Contributes {}"
@@ -24,12 +25,12 @@ CARD_BUTTON_FORMAT = "As {} base ({}x): Deals {}"
 
 MonsterStat = namedtuple('MonsterStat', 'name id mult att')
 
-team_buttons = [
+TEAM_BUTTONS = [
     MonsterStat("Nergi Hunter", 4172, 40, [2, 4]),
     MonsterStat("Oversoul", 5273, 50, [0, 1, 2, 3, 4]),
     MonsterStat("Ryuno Ume", 5252, 80, [2, 4])
 ]
-card_buttons = [
+CARD_BUTTONS = [
     MonsterStat("Satan", 4286, 300, []),
     MonsterStat("Brachydios", 4134, 350, []),
     MonsterStat("Rajang", 5527, 550, []),
@@ -92,24 +93,24 @@ class ButtonInfo:
         return 1 / 3
 
     def to_string(self, monster, info):
-        card_btn_str = self._get_card_btn_damage(card_buttons, info, monster)
-        team_btn_str = self._get_team_btn_damage(team_buttons, info, monster)
+        card_btn_str = self._get_card_btn_damage(CARD_BUTTONS, info, monster)
+        team_btn_str = self._get_team_btn_damage(TEAM_BUTTONS, info, monster)
         return INFO_STRING.format(monster.monster_id, monster.name_en, info.main_damage, info.sub_damage,
                                   info.total_damage,
                                   info.main_damage_with_atk_latent, info.sub_damage_with_atk_latent,
                                   info.total_damage_with_atk_latent, card_btn_str, team_btn_str)
 
     def _get_card_btn_damage(self, card_buttons, info, monster):
-        ret_str = ""
+        lines = []
         card_buttons.sort(key=lambda x: x.mult)
         for card in card_buttons:
-            ret_str += "\n" + CARD_BUTTON_FORMAT.format(card.name, card.mult,
-                                                        (info.main_damage_with_atk_latent * card.mult))
-        return ret_str
+            lines.append(CARD_BUTTON_FORMAT.format(card.name, card.mult,
+                         (info.main_damage_with_atk_latent * card.mult)))
+        return "\n".join(lines)
 
     def _get_team_btn_damage(self, team_buttons, info, monster):
         # TODO: calculate with oncolor assist damage and ATK+ eq (Oversoul)
-        ret_str = ""
+        lines = []
         team_buttons.sort(key=lambda x: x.mult)
         for card in team_buttons:
             total_dmg = 0
@@ -120,8 +121,8 @@ class ButtonInfo:
             colors_str = ""
             for i in card.att:
                 colors_str += COLORS[i]
-            ret_str += "\n" + TEAM_BUTTON_FORMAT.format(card.name, card.mult, colors_str, (total_dmg * card.mult))
-        return ret_str
+            lines.append(TEAM_BUTTON_FORMAT.format(card.name, card.mult, colors_str, (total_dmg * card.mult)))
+        return "\n".join(lines)
 
 
 class ButtonInfoResult:

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -63,28 +63,21 @@ class ButtonInfo:
         sub_attr_multiplier = self._get_sub_attr_multiplier(monster_model)
 
         result = ButtonInfoResult()
-        result.main_damage = self._calculate_damage(
-            dgcog, monster_model, max_level, 0)
+        result.main_damage = self._calculate_damage(dgcog, monster_model, max_level, 0)
         result.sub_damage = result.main_damage * sub_attr_multiplier
         result.total_damage = result.main_damage + result.sub_damage
 
-        result.main_damage_with_atk_latent = self._calculate_damage(
-            dgcog, monster_model, max_level, max_atk_latents)
+        result.main_damage_with_atk_latent = self._calculate_damage(dgcog, monster_model, max_level, max_atk_latents)
         result.sub_damage_with_atk_latent = result.main_damage_with_atk_latent * sub_attr_multiplier
-        result.total_damage_with_atk_latent = result.main_damage_with_atk_latent + \
-            result.sub_damage_with_atk_latent
+        result.total_damage_with_atk_latent = result.main_damage_with_atk_latent + result.sub_damage_with_atk_latent
         return result
 
     def _calculate_damage(self, dgcog, monster_model, level, num_atkpp_latent=0):
-        stat_latents = dgcog.MonsterStatModifierInput(
-            num_atkpp=num_atkpp_latent)
-        stat_latents.num_atk_awakening = len(
-            [x for x in monster_model.awakenings if x.awoken_skill_id == 1])
+        stat_latents = dgcog.MonsterStatModifierInput(num_atkpp=num_atkpp_latent)
+        stat_latents.num_atk_awakening = len([x for x in monster_model.awakenings if x.awoken_skill_id == 1])
 
-        dmg = dgcog.monster_stats.stat(
-            monster_model, 'atk', level, stat_latents=stat_latents)
-        num_mult_boost = len(
-            [x for x in monster_model.awakenings if x.awoken_skill_id == 30])
+        dmg = dgcog.monster_stats.stat(monster_model, 'atk', level, stat_latents=stat_latents)
+        num_mult_boost = len([x for x in monster_model.awakenings if x.awoken_skill_id == 30])
 
         dmg *= 1.5 ** num_mult_boost
         return dmg
@@ -97,11 +90,10 @@ class ButtonInfo:
         return 1 / 3
 
     def to_string(self, monster, info):
-        damage_str = self._get_btn_damage(
-            team_buttons, card_buttons, info, monster)
-        return INFO_STRING.format(monster.monster_id, monster.name_en, info.main_damage, info.sub_damage,
-                                  info.total_damage,
-                                  info.main_damage_with_atk_latent, info.sub_damage_with_atk_latent,
+        damage_str = self._get_btn_damage(Fteam_buttons, card_buttons, info, monster)
+        return INFO_STRING.format(monster.monster_id, monster.name_en, info.main_damage, info.sub_damage, 
+                                  info.total_damage, 
+                                  info.main_damage_with_atk_latent, info.sub_damage_with_atk_latent, 
                                   info.total_damage_with_atk_latent, damage_str)
 
     def _get_btn_damage(self, tb, cb, info, monster):
@@ -110,9 +102,7 @@ class ButtonInfo:
         cb.sort(key=lambda x: x.mult)
         tb.sort(key=lambda x: x.mult)
         for x in cb:
-            ret_str += "\n" + \
-                CARD_BUTTON_FORMAT.format(
-                    x.name, x.mult, (info.main_damage_with_atk_latent * x.mult))
+            ret_str += "\n" + CARD_BUTTON_FORMAT.format(x.name, x.mult, (info.main_damage_with_atk_latent * x.mult))
         for x in tb:
             total_dmg = 0
             if(monster.attr1.value in x.att):
@@ -122,9 +112,7 @@ class ButtonInfo:
             colors_str = ""
             for i in x.att:
                 colors_str += COLORS[i]
-            ret_str += "\n" + \
-                TEAM_BUTTON_FORMAT.format(
-                    x.name, x.mult, colors_str, (total_dmg * x.mult))
+            ret_str += "\n" + TEAM_BUTTON_FORMAT.format(x.name, x.mult, colors_str, (total_dmg * x.mult))
         return ret_str
 
 

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 LIMIT_BREAK_LEVEL = 110
 
 INFO_STRING = """[{}] {}
@@ -12,12 +14,31 @@ With Latents:
 Base:    {}
 Subattr: {}
 Total:   {}
+
+--------------
+{}
 """
+
+TEAM_BUTTON_FORMAT = "As {} base ({}x {}): Contributes {}"
+CARD_BUTTON_FORMAT = "As {} base ({}x): Deals {}"
+
+team_buttons = []
+card_buttons = []
+
+MonsterStat = namedtuple('MonsterStat', 'name id mult att')
+team_buttons.append(MonsterStat("Nergi Hunter", 4172, 40, [2, 4]))
+team_buttons.append(MonsterStat("Oversoul", 5273, 50, [0, 1, 2, 3, 4]))
+team_buttons.append(MonsterStat("Ryuno Ume", 5252, 80, [2, 4]))
+card_buttons.append(MonsterStat("Satan", 4286, 300, []))
+card_buttons.append(MonsterStat("Brachydios", 4134, 350, []))
+card_buttons.append(MonsterStat("Rajang", 5527, 550, []))
+card_buttons.append(MonsterStat("Balrog", 5108, 450, []))
+
+COLORS = ["R", "B", "G", "L", "D"]
 
 
 class ButtonInfo:
     def get_info(self, dgcog, monster_model):
-
         """
         Usage: ^buttoninfo Vajrayasaka
 
@@ -42,21 +63,28 @@ class ButtonInfo:
         sub_attr_multiplier = self._get_sub_attr_multiplier(monster_model)
 
         result = ButtonInfoResult()
-        result.main_damage = self._calculate_damage(dgcog, monster_model, max_level, 0)
+        result.main_damage = self._calculate_damage(
+            dgcog, monster_model, max_level, 0)
         result.sub_damage = result.main_damage * sub_attr_multiplier
         result.total_damage = result.main_damage + result.sub_damage
 
-        result.main_damage_with_atk_latent = self._calculate_damage(dgcog, monster_model, max_level, max_atk_latents)
+        result.main_damage_with_atk_latent = self._calculate_damage(
+            dgcog, monster_model, max_level, max_atk_latents)
         result.sub_damage_with_atk_latent = result.main_damage_with_atk_latent * sub_attr_multiplier
-        result.total_damage_with_atk_latent = result.main_damage_with_atk_latent + result.sub_damage_with_atk_latent
+        result.total_damage_with_atk_latent = result.main_damage_with_atk_latent + \
+            result.sub_damage_with_atk_latent
         return result
 
     def _calculate_damage(self, dgcog, monster_model, level, num_atkpp_latent=0):
-        stat_latents = dgcog.MonsterStatModifierInput(num_atkpp=num_atkpp_latent)
-        stat_latents.num_atk_awakening = len([x for x in monster_model.awakenings if x.awoken_skill_id == 1])
+        stat_latents = dgcog.MonsterStatModifierInput(
+            num_atkpp=num_atkpp_latent)
+        stat_latents.num_atk_awakening = len(
+            [x for x in monster_model.awakenings if x.awoken_skill_id == 1])
 
-        dmg = dgcog.monster_stats.stat(monster_model, 'atk', level, stat_latents=stat_latents)
-        num_mult_boost = len([x for x in monster_model.awakenings if x.awoken_skill_id == 30])
+        dmg = dgcog.monster_stats.stat(
+            monster_model, 'atk', level, stat_latents=stat_latents)
+        num_mult_boost = len(
+            [x for x in monster_model.awakenings if x.awoken_skill_id == 30])
 
         dmg *= 1.5 ** num_mult_boost
         return dmg
@@ -69,10 +97,35 @@ class ButtonInfo:
         return 1 / 3
 
     def to_string(self, monster, info):
+        damage_str = self._get_btn_damage(
+            team_buttons, card_buttons, info, monster)
         return INFO_STRING.format(monster.monster_id, monster.name_en, info.main_damage, info.sub_damage,
                                   info.total_damage,
                                   info.main_damage_with_atk_latent, info.sub_damage_with_atk_latent,
-                                  info.total_damage_with_atk_latent)
+                                  info.total_damage_with_atk_latent, damage_str)
+
+    def _get_btn_damage(self, tb, cb, info, monster):
+        # TODO: calculate with oncolor assist damage and ATK+ eq (Oversoul)
+        ret_str = ""
+        cb.sort(key=lambda x: x.mult)
+        tb.sort(key=lambda x: x.mult)
+        for x in cb:
+            ret_str += "\n" + \
+                CARD_BUTTON_FORMAT.format(
+                    x.name, x.mult, (info.main_damage_with_atk_latent * x.mult))
+        for x in tb:
+            total_dmg = 0
+            if(monster.attr1.value in x.att):
+                total_dmg += info.main_damage_with_atk_latent
+            if(monster.attr2.value in x.att):
+                total_dmg += info.sub_damage_with_atk_latent
+            colors_str = ""
+            for i in x.att:
+                colors_str += COLORS[i]
+            ret_str += "\n" + \
+                TEAM_BUTTON_FORMAT.format(
+                    x.name, x.mult, colors_str, (total_dmg * x.mult))
+        return ret_str
 
 
 class ButtonInfoResult:

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -16,23 +16,25 @@ Subattr: {}
 Total:   {}
 
 --------------
-{}
+{}{}
 """
 
 TEAM_BUTTON_FORMAT = "As {} base ({}x {}): Contributes {}"
 CARD_BUTTON_FORMAT = "As {} base ({}x): Deals {}"
 
-team_buttons = []
-card_buttons = []
-
 MonsterStat = namedtuple('MonsterStat', 'name id mult att')
-team_buttons.append(MonsterStat("Nergi Hunter", 4172, 40, [2, 4]))
-team_buttons.append(MonsterStat("Oversoul", 5273, 50, [0, 1, 2, 3, 4]))
-team_buttons.append(MonsterStat("Ryuno Ume", 5252, 80, [2, 4]))
-card_buttons.append(MonsterStat("Satan", 4286, 300, []))
-card_buttons.append(MonsterStat("Brachydios", 4134, 350, []))
-card_buttons.append(MonsterStat("Rajang", 5527, 550, []))
-card_buttons.append(MonsterStat("Balrog", 5108, 450, []))
+
+team_buttons = [
+    MonsterStat("Nergi Hunter", 4172, 40, [2, 4]),
+    MonsterStat("Oversoul", 5273, 50, [0, 1, 2, 3, 4]),
+    MonsterStat("Ryuno Ume", 5252, 80, [2, 4])
+]
+card_buttons = [
+    MonsterStat("Satan", 4286, 300, []),
+    MonsterStat("Brachydios", 4134, 350, []),
+    MonsterStat("Rajang", 5527, 550, []),
+    MonsterStat("Balrog", 5108, 450, [])
+]
 
 COLORS = ["R", "B", "G", "L", "D"]
 
@@ -90,29 +92,35 @@ class ButtonInfo:
         return 1 / 3
 
     def to_string(self, monster, info):
-        damage_str = self._get_btn_damage(Fteam_buttons, card_buttons, info, monster)
-        return INFO_STRING.format(monster.monster_id, monster.name_en, info.main_damage, info.sub_damage, 
-                                  info.total_damage, 
-                                  info.main_damage_with_atk_latent, info.sub_damage_with_atk_latent, 
-                                  info.total_damage_with_atk_latent, damage_str)
+        card_btn_str = self._get_card_btn_damage(card_buttons, info, monster)
+        team_btn_str = self._get_team_btn_damage(team_buttons, info, monster)
+        return INFO_STRING.format(monster.monster_id, monster.name_en, info.main_damage, info.sub_damage,
+                                  info.total_damage,
+                                  info.main_damage_with_atk_latent, info.sub_damage_with_atk_latent,
+                                  info.total_damage_with_atk_latent, card_btn_str, team_btn_str)
 
-    def _get_btn_damage(self, tb, cb, info, monster):
+    def _get_card_btn_damage(self, card_buttons, info, monster):
+        ret_str = ""
+        card_buttons.sort(key=lambda x: x.mult)
+        for card in card_buttons:
+            ret_str += "\n" + CARD_BUTTON_FORMAT.format(card.name, card.mult,
+                                                        (info.main_damage_with_atk_latent * card.mult))
+        return ret_str
+
+    def _get_team_btn_damage(self, team_buttons, info, monster):
         # TODO: calculate with oncolor assist damage and ATK+ eq (Oversoul)
         ret_str = ""
-        cb.sort(key=lambda x: x.mult)
-        tb.sort(key=lambda x: x.mult)
-        for x in cb:
-            ret_str += "\n" + CARD_BUTTON_FORMAT.format(x.name, x.mult, (info.main_damage_with_atk_latent * x.mult))
-        for x in tb:
+        team_buttons.sort(key=lambda x: x.mult)
+        for card in team_buttons:
             total_dmg = 0
-            if(monster.attr1.value in x.att):
+            if(monster.attr1.value in card.att):
                 total_dmg += info.main_damage_with_atk_latent
-            if(monster.attr2.value in x.att):
+            if(monster.attr2.value in card.att):
                 total_dmg += info.sub_damage_with_atk_latent
             colors_str = ""
-            for i in x.att:
+            for i in card.att:
                 colors_str += COLORS[i]
-            ret_str += "\n" + TEAM_BUTTON_FORMAT.format(x.name, x.mult, colors_str, (total_dmg * x.mult))
+            ret_str += "\n" + TEAM_BUTTON_FORMAT.format(card.name, card.mult, colors_str, (total_dmg * card.mult))
         return ret_str
 
 


### PR DESCRIPTION
Adds damage info for different button inherits on the card. 
fixes #932 
```
[5325] Reincarnated Vajrabhairava
(Co-op mode)

Without Latents:
Base:    7152.75
Subattr: 2384.25
Total:   9537.0

With Latents:
Base:    7877.25
Subattr: 2625.75
Total:   10503.0

--------------

As Satan base (300x): Deals 2363175.0
As Brachydios base (350x): Deals 2757037.5
As Balrog base (450x): Deals 3544762.5
As Rajang base (550x): Deals 4332487.5
As Nergi Hunter base (40x GD): Contributes 315090.0
As Oversoul base (50x RBGLD): Contributes 525150.0
As Ryuno Ume base (80x GD): Contributes 630180.0
```