### PR TITLE
Use discord-menu view state as base class

### DIFF
--- a/padinfo/view/components/base.py
+++ b/padinfo/view/components/base.py
@@ -1,10 +1,6 @@
-from typing import Union
-
 from discordmenu.embed.components import EmbedFooter
+from discordmenu.embed.view_state import ViewState
 from discordmenu.intra_message_state import IntraMessageState
-
-from padinfo.view.components.view_state_base import ViewStateBase
-from padinfo.view.components.view_state_base_id import ViewStateBaseId
 
 TSUBAKI_FLOWER_ICON_URL = 'https://d1kpnpud0qoyxf.cloudfront.net/tsubaki/tsubakiflower.png'
 
@@ -13,7 +9,7 @@ def pad_info_footer():
     return EmbedFooter('Requester may click the reactions below to switch tabs')
 
 
-def pad_info_footer_with_state(state: Union[ViewStateBase, ViewStateBaseId]):
+def pad_info_footer_with_state(state: ViewState):
     url = IntraMessageState.serialize(TSUBAKI_FLOWER_ICON_URL, state.serialize())
     return EmbedFooter(
         'Requester may click the reactions below to switch tabs',

--- a/padinfo/view/components/view_state_base.py
+++ b/padinfo/view/components/view_state_base.py
@@ -1,21 +1,16 @@
 from typing import List
 
+from discordmenu.embed.view_state import ViewState
 
-class ViewStateBase:
+
+class ViewStateBase(ViewState):
     def __init__(self, original_author_id, menu_type, raw_query, extra_state=None, reaction_list: List = None):
-        self.extra_state = extra_state or {}
-        self.menu_type = menu_type
-        self.original_author_id = original_author_id
-        self.raw_query = raw_query
         self.reaction_list = reaction_list
+        super().__init__(original_author_id=original_author_id, menu_type=menu_type, raw_query=raw_query,
+                         extra_state=extra_state)
 
     def serialize(self):
-        ret = {
-            'raw_query': self.raw_query,
-            'menu_type': self.menu_type,
-            'original_author_id': self.original_author_id,
-        }
-        ret.update(self.extra_state)
+        ret = super().serialize()
         if self.reaction_list is not None:
             ret['reaction_list'] = self.reaction_list
         return ret

--- a/padinfo/view/components/view_state_base_id.py
+++ b/padinfo/view/components/view_state_base_id.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, List
 
+from discordmenu.embed.view_state import ViewState
+
 from padinfo.common.config import UserConfig
 from padinfo.view.common import get_monster_from_ims
 
@@ -7,17 +9,15 @@ if TYPE_CHECKING:
     from dadguide.models.monster_model import MonsterModel
 
 
-class ViewStateBaseId:
+class ViewStateBaseId(ViewState):
     def __init__(self, original_author_id, menu_type, raw_query, query, color, monster: "MonsterModel",
                  alt_monsters: List["MonsterModel"],
                  use_evo_scroll: bool = True,
                  reaction_list: List[str] = None,
                  extra_state=None):
+        super().__init__(original_author_id=original_author_id, menu_type=menu_type, raw_query=raw_query,
+                         extra_state=extra_state)
         self.alt_monsters = alt_monsters
-        self.extra_state = extra_state or {}
-        self.menu_type = menu_type
-        self.original_author_id = original_author_id
-        self.raw_query = raw_query
         self.reaction_list = reaction_list
         self.color = color
         self.monster = monster
@@ -25,16 +25,13 @@ class ViewStateBaseId:
         self.use_evo_scroll = use_evo_scroll
 
     def serialize(self):
-        ret = {
-            'raw_query': self.raw_query,
-            'menu_type': self.menu_type,
-            'original_author_id': self.original_author_id,
+        ret = super().serialize()
+        ret.update({
             'query': self.query,
             'resolved_monster_id': self.monster.monster_id,
             'use_evo_scroll': str(self.use_evo_scroll),
             'reaction_list': self.reaction_list,
-        }
-        ret.update(self.extra_state)
+        })
         return ret
 
     @classmethod


### PR DESCRIPTION
Doing this so that the type annotation for `pad_info_footer_with_state` can be just `ViewState` so that we can move it to `tsutils` so that it can be used in every cog without being duplicated