### PR TITLE
Sort evo trees with a dfs instead of bfs

### DIFF
--- a/dadguide/find_monster.py
+++ b/dadguide/find_monster.py
@@ -212,6 +212,7 @@ class FindMonster:
             tokenized_query = []
 
         return (matches[monster].score,
+                not self.dgcog.database.graph.monster_is_evo_gem(monster),
                 # Don't deprio evos with new modifier
                 not monster.is_equip if not {m[0] for m in matches[monster].mod}.intersection(
                     {'new', 'base'}) else True,

--- a/dadguide/models/monster_model.py
+++ b/dadguide/models/monster_model.py
@@ -20,6 +20,7 @@ class MonsterModel(BaseModel):
         self.monster_no_jp = m['monster_no_jp']
         self.monster_no_na = m['monster_no_na']
         self.monster_no_kr = m['monster_no_kr']
+        self.base_evo_id = m['base_evo_id']
 
         # these things are literally named backwards atm
         self.awakenings = sorted(m['awakenings'], key=lambda a: a.order_idx)

--- a/dadguide/monster_index.py
+++ b/dadguide/monster_index.py
@@ -3,7 +3,6 @@ import csv
 import io
 import logging
 import re
-from collections import defaultdict
 
 import aiohttp
 import tsutils
@@ -48,7 +47,6 @@ class MonsterIndex(tsutils.aobject):
         self.replacement_tokens = defaultdict(set)
         self.remove_mods = defaultdict(set)
         self.treename_overrides = set()
-
 
         nickname_data, treenames_data, pantheon_data, nt_alias_data, mod_data, treemod_data = await asyncio.gather(
             sheet_to_reader(NICKNAME_OVERRIDES_SHEET, 5),
@@ -417,7 +415,7 @@ class MonsterIndex(tsutils.aobject):
 
         if self.graph.monster_is_rem_evo(monster):
             modifiers.update(MISC_MAP[MiscModifiers.REM])
-        else: 
+        else:
             if self.graph.monster_is_vendor_exchange(monster):
                 modifiers.update(MISC_MAP[MiscModifiers.MEDAL_EXC])
             if self.graph.monster_is_mp_evo(monster):
@@ -450,7 +448,7 @@ class MonsterIndex(tsutils.aobject):
     def add_numbered_modifier(self, monster, curr_mods, added_mods, condition, *, else_mods=None):
         if condition(monster):
             curr_mods.update(added_mods)
-            ms = sorted((m for m in self.graph.get_alt_monsters(monster) if condition(m)), key=lambda m: m.monster_id)
+            ms = [m for m in self.graph.get_alt_monsters(monster) if condition(m)]
             if len(ms) > 1:
                 curr_mods.update(f'{mod}-{ms.index(monster) + 1}' for mod in added_mods)
         elif else_mods:

--- a/padinfo/core/transforminfo.py
+++ b/padinfo/core/transforminfo.py
@@ -9,7 +9,7 @@ async def perform_transforminfo_query(dgcog, raw_query, author_id):
     transformed_mon = None
     base_mon = None
     altversions = mgraph.process_alt_versions(found_monster.monster_id)
-    for mon_id in sorted(altversions):
+    for mon_id in altversions:
         if mgraph.monster_is_transform_base_by_id(mon_id):
             transformed_mon = dgcog.get_monster(mgraph.get_next_transform_id_by_monster_id(mon_id))
             if transformed_mon:

--- a/padinfo/menu/id.py
+++ b/padinfo/menu/id.py
@@ -50,7 +50,7 @@ class IdMenu:
     @staticmethod
     def get_prev_monster_id(db_context: "DbContext", monster: "MonsterModel", use_evo_scroll):
         if use_evo_scroll:
-            evos = sorted({*db_context.graph.get_alt_ids_by_id(monster.monster_id)})
+            evos = db_context.graph.get_alt_ids_by_id(monster.monster_id)
             index = evos.index(monster.monster_id)
             new_id = evos[index - 1]
             return new_id
@@ -77,7 +77,7 @@ class IdMenu:
     @staticmethod
     def get_next_monster_id(db_context: "DbContext", monster: "MonsterModel", use_evo_scroll):
         if use_evo_scroll:
-            evos = sorted({*db_context.graph.get_alt_ids_by_id(monster.monster_id)})
+            evos = db_context.graph.get_alt_ids_by_id(monster.monster_id)
             index = evos.index(monster.monster_id)
             if index == len(evos) - 1:
                 # cycle back to the beginning of the evos list

--- a/padinfo/view/components/view_state_base_id.py
+++ b/padinfo/view/components/view_state_base_id.py
@@ -56,6 +56,5 @@ class ViewStateBaseId(ViewState):
     @classmethod
     def get_alt_monsters(cls, dgcog, monster):
         db_context = dgcog.database
-        alt_monsters = sorted(db_context.graph.get_alt_monsters_by_id(monster.monster_no),
-                              key=lambda x: x.monster_id)
+        alt_monsters = db_context.graph.get_alt_monsters_by_id(monster.monster_id)
         return alt_monsters


### PR DESCRIPTION
This changes the base id of 6 monsters, so the treename sheet will need to be updated.
1 -> 1929
5 -> 1930
9 -> 1931
1803 -> 1810
2926 -> 2978
5802 -> 5810