### PR TITLE
Update UX for padglobal which

### DIFF
--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -753,7 +753,7 @@ class PadGlobal(commands.Cog):
     async def addwhich(self, ctx, term, *, definition):
         """Adds an entry to the which monster evo list.
 
-        If you provide a monster ID, the term will be entered for that monster tree.
+        Accepts queries. The which text will be entered for the resulting monster's tree.
         e.x. [p]padglobal addwhich 3818 take the pixel one
         """
         dgcog = self.bot.get_cog("Dadguide")

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -769,7 +769,7 @@ class PadGlobal(commands.Cog):
                                                             m.name_en)):
             return
         self.settings.addWhich(name, definition)
-        await ctx.send("PAD which info successfully {}.".format(op))
+        await ctx.send("PAD which info successfully {} for [{}] {}.".format(op, m.monster_id, m.name_en))
 
     @padglobal.command()
     async def rmwhich(self, ctx, *, monster_id: int):

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -786,7 +786,7 @@ class PadGlobal(commands.Cog):
         definition = definition.replace(u'\u200b', '')
         definition = replace_emoji_names_with_code(self._get_emojis(), definition)
         self.settings.addWhich(name, definition)
-        await ctx.send("PAD which info successfully {} for [{}] {}.".format(op, m.monster_id, m.name_en))
+        await ctx.send("PAD which info successfully {} for [{}] {}.".format(op, m.monster_no_na, m.name_en))
 
     @padglobal.command()
     async def rmwhich(self, ctx, *, monster_id: int):

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -858,10 +858,10 @@ class PadGlobal(commands.Cog):
 
         if operation == 'prepend':
             self.settings.addWhich(mon_id, '{}\n\n{}'.format(addition, definition))
-            await ctx.send("Successfully PREPENDED to PAD which info for {}.".format(m.name_en))
+            await ctx.send("Successfully PREPENDED to PAD which info for [{}] {}.".format(m.monster_no_na, m.name_en))
         elif operation == 'append':
             self.settings.addWhich(mon_id, '{}\n\n{}'.format(definition, addition))
-            await ctx.send("Successfully APPENDED to PAD which info for {}.".format(m.name_en))
+            await ctx.send("Successfully APPENDED to PAD which info for [{}] {}.".format(m.monster_no_na, m.name_en))
         else:
             raise KeyError("Invalid operation: Must be \'prepend\' or \'append\'")
 

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -766,13 +766,12 @@ class PadGlobal(commands.Cog):
             return
 
         base_monster = dgcog.database.graph.get_base_monster(m)
-
-        is_int = re.fullmatch(r'\d+', term)
-
         if m != base_monster:
             m = base_monster
             await ctx.send("I think you meant {} for {}.".format(m.monster_no_na, m.name_en))
         name = m.monster_id
+
+        is_int = re.fullmatch(r'\d+', term)
 
         op = 'EDITED' if name in self.settings.which() else 'ADDED'
         if op == 'ADDED' and not is_int or op == 'EDITED':

--- a/padglobal/view/which.py
+++ b/padglobal/view/which.py
@@ -20,7 +20,7 @@ class WhichViewProps:
 
 def _get_field(paragraph, color):
     lines = paragraph.strip().splitlines()
-    lines = [_replace_bullets(line, color) for line in lines]
+    lines = [_replace_bullets(line.strip(), color) for line in lines]
 
     if len(lines) > 1:
         evo = lines[0]


### PR DESCRIPTION
Resolves #1075. Resolves #1078.

* Updates completion messages with the name of the monster.
* Updates `addwhich`, `prependwhich`, and `appendwhich` to accept query terms instead of just monster ids. Prompts for additional confirmation if the given term is not an id.
* Also fixes parsing of `which` embed bullet points if the `* ` comes after errant whitespace.

![image](https://user-images.githubusercontent.com/72906298/119211092-2c7d8000-ba7e-11eb-8d01-c9ff201418e5.png)
![image](https://user-images.githubusercontent.com/72906298/119211093-2edfda00-ba7e-11eb-9a31-dc034ad94a24.png)