### PR TITLE
Update pwhich dump and list

### DIFF
--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -897,9 +897,9 @@ class PadGlobal(commands.Cog):
                 content = box(page.replace('`', u'\u200b`'))
                 await ctx.send(content)
 
-    @pwhich.command(name='get')
-    async def pwhich_get(self, ctx):
-        """Gets a list of all which commands."""
+    @pwhich.command(name='list')
+    async def pwhich_list(self, ctx):
+        """List all which commands."""
         items = list()
         monsters = []
         for w in self.settings.which():

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -905,7 +905,7 @@ class PadGlobal(commands.Cog):
         channel = '\N{WHITE HEAVY CHECK MARK}'
         send_as_dm = '\N{ENVELOPE}'
         cancel = '\N{CROSS MARK}'
-        destination = cancel
+        destination = channel
         if len(self.settings.which()) > MAX_WHICH_LIST_BEFORE_DM_PROMPT:
             destination = await get_reaction(ctx,
                                              'This will send a lot of messages. Are you sure? '

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -902,17 +902,18 @@ class PadGlobal(commands.Cog):
     @pwhich.command(name='list')
     async def pwhich_list(self, ctx):
         """List all which commands."""
-        affirmative = '\N{WHITE HEAVY CHECK MARK}'
-        negative = '\N{CROSS MARK}'
-        cancel = '\N{WASTEBASKET}'
-        send_as_dm = negative
+        channel = '\N{WHITE HEAVY CHECK MARK}'
+        send_as_dm = '\N{ENVELOPE}'
+        cancel = '\N{CROSS MARK}'
+        destination = cancel
         if len(self.settings.which()) > MAX_WHICH_LIST_BEFORE_DM_PROMPT:
-            send_as_dm = await get_reaction(ctx,
-                                            'This will send a long list. Do you want it as a DM? (Trash to cancel.)',
-                                            affirmative,
-                                            negative,
-                                            cancel)
-        if send_as_dm == cancel or send_as_dm is None:
+            destination = await get_reaction(ctx,
+                                             'This will send a lot of messages. Are you sure? '
+                                             + '(Yes / DM me instead / Cancel)',
+                                             channel,
+                                             send_as_dm,
+                                             cancel)
+        if destination == cancel or destination is None:
             return
 
         items = list()
@@ -939,7 +940,7 @@ class PadGlobal(commands.Cog):
         msg = tsutils.strip_right_multiline(tbl.get_string())
 
         for page in pagify(msg):
-            if send_as_dm == negative:
+            if destination == channel:
                 await ctx.send(box(page))
             else:
                 await ctx.author.send(box(page))

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -893,8 +893,9 @@ class PadGlobal(commands.Cog):
         if definition is None:
             return
         else:
-            content = box(definition.replace('`', u'\u200b`'))
-            await ctx.send(content)
+            for page in pagify(definition):
+                content = box(page.replace('`', u'\u200b`'))
+                await ctx.send(content)
 
     @pwhich.command(name='get')
     async def pwhich_get(self, ctx):

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -57,6 +57,8 @@ MP_BUY_MSG = ('This monster can be purchased with MP. **DO NOT** buy MP cards wi
               ', check `{}mpdra?` for specific recommendations.')
 SIMPLE_TREE_MSG = 'This monster appears to be uncontroversial; use the highest evolution: `[{}] {}`.'
 
+WHICH_LIMIT = 30
+
 
 def mod_help(self, ctx, help_type):
     hs = getattr(self, help_type)
@@ -900,6 +902,13 @@ class PadGlobal(commands.Cog):
     @pwhich.command(name='list')
     async def pwhich_list(self, ctx):
         """List all which commands."""
+        confirmed = False
+        if len(self.settings.which()) > WHICH_LIMIT:
+            confirmed = await confirm_message(ctx, 'This will send a long list. Do you really want it sent to this '
+                                                 + 'channel (instead of DM)? Cancel action by not reacting.')
+        if confirmed is None:
+            return
+
         items = list()
         monsters = []
         for w in self.settings.which():
@@ -924,7 +933,10 @@ class PadGlobal(commands.Cog):
         msg = tsutils.strip_right_multiline(tbl.get_string())
 
         for page in pagify(msg):
-            await ctx.send(box(page))
+            if confirmed:
+                await ctx.send(box(page))
+            else:
+                await ctx.author.send(box(page))
 
     @padglobal.group()
     @checks.is_owner()

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -57,7 +57,7 @@ MP_BUY_MSG = ('This monster can be purchased with MP. **DO NOT** buy MP cards wi
               ', check `{}mpdra?` for specific recommendations.')
 SIMPLE_TREE_MSG = 'This monster appears to be uncontroversial; use the highest evolution: `[{}] {}`.'
 
-WHICH_LIMIT = 30
+MAX_WHICH_LIST_BEFORE_DM_PROMPT = 30
 
 
 def mod_help(self, ctx, help_type):
@@ -906,7 +906,7 @@ class PadGlobal(commands.Cog):
         negative = '\N{CROSS MARK}'
         cancel = '\N{WASTEBASKET}'
         send_as_dm = negative
-        if len(self.settings.which()) > WHICH_LIMIT:
+        if len(self.settings.which()) > MAX_WHICH_LIST_BEFORE_DM_PROMPT:
             send_as_dm = await get_reaction(ctx,
                                             'This will send a long list. Do you want it as a DM? (Trash to cancel.)',
                                             affirmative,


### PR DESCRIPTION
* Renames `pwhich get` to `list`.
* Fixes `pwhich dump`, because when I implemented it I neglected to make it work properly.
* Allows the user to get the result of `pwhich list` as a DM or cancel altogether when there are a lot of which entries.