### PR TITLE
Warn of aliases when using padglobal delete

### DIFF
--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -275,6 +275,7 @@ class PadGlobal(commands.Cog):
 
 
         if command in self.c_commands:
+            alias = self.c_commands[command] in self.c_commands
             ocm = self.c_commands.copy()
             self.c_commands.pop(command, None)
             todel = [command]
@@ -285,7 +286,7 @@ class PadGlobal(commands.Cog):
                         self.c_commands.pop(comm, None)
                         todel.append(comm)
             json.dump(self.c_commands, open(self.file_path, 'w+'))
-            await ctx.send("PAD command successfully deleted.")
+            await ctx.send("PAD {} successfully deleted.".format('alias' if alias else 'command'))
         else:
             await ctx.send("PAD command doesn't exist.")
 

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -236,6 +236,9 @@ class PadGlobal(commands.Cog):
 
         if text in self.c_commands:
             op = 'ALIASED'
+            if text == command:
+                await ctx.send('You cannot alias something to itself.')
+                return
             if self.c_commands[text] in self.c_commands:
                 await ctx.send("You cannot alias an alias")
                 return

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -276,7 +276,6 @@ class PadGlobal(commands.Cog):
                 await ctx.send('Cancelling delete of `{}`.'.format(command))
                 return
 
-
         if command in self.c_commands:
             alias = self.c_commands[command] in self.c_commands
             ocm = self.c_commands.copy()
@@ -329,7 +328,6 @@ class PadGlobal(commands.Cog):
         for cmd in self.c_commands:
             if self.c_commands[cmd] == command:
                 aliases.append(cmd)
-
         return aliases
 
     @padglobal.command()

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -288,7 +288,7 @@ class PadGlobal(commands.Cog):
                         self.c_commands.pop(comm, None)
                         todel.append(comm)
             json.dump(self.c_commands, open(self.file_path, 'w+'))
-            await ctx.send("PAD {} successfully deleted.".format('alias' if alias else 'command'))
+            await ctx.send("PAD **{}** successfully deleted.".format('alias' if alias else 'command'))
         else:
             await ctx.send("PAD command doesn't exist.")
 

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -271,8 +271,9 @@ class PadGlobal(commands.Cog):
 
         aliases = await self._find_aliases(command)
         if aliases:
-            if not await confirm_message(ctx, 'Are you sure? `{}` has alias(es) `{}` which will also be deleted.'
-                                         .format(command, '`, `'.join(aliases))):
+            if not await confirm_message(ctx,
+                                         'Are you sure? `{}` has **{}** alias(es): `{}` which will also be deleted.'
+                                         .format(command, len(aliases), '`, `'.join(aliases))):
                 await ctx.send('Cancelling delete of `{}`.'.format(command))
                 return
 

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -265,6 +265,15 @@ class PadGlobal(commands.Cog):
         Example:
         [p]padglobal delete yourcommand"""
         command = command.lower()
+
+        aliases = await self._find_aliases(command)
+        if aliases:
+            if not await confirm_message(ctx, 'Are you sure? `{}` has alias(es) `{}` which will also be deleted.'
+                                         .format(command, '`, `'.join(aliases))):
+                await ctx.send('Cancelling delete of `{}`.'.format(command))
+                return
+
+
         if command in self.c_commands:
             ocm = self.c_commands.copy()
             self.c_commands.pop(command, None)
@@ -310,6 +319,14 @@ class PadGlobal(commands.Cog):
 
         await ctx.send("Successfully appended to {}PAD command `{}`.".format("source " if alias else "",
                                                                              source_cmd if alias else corrected_cmd))
+
+    async def _find_aliases(self, command: str):
+        aliases = []
+        for cmd in self.c_commands:
+            if self.c_commands[cmd] == command:
+                aliases.append(cmd)
+
+        return aliases
 
     @padglobal.command()
     async def setgeneral(self, ctx, command: str):

--- a/padglobal/padglobal.py
+++ b/padglobal/padglobal.py
@@ -289,7 +289,7 @@ class PadGlobal(commands.Cog):
                         self.c_commands.pop(comm, None)
                         todel.append(comm)
             json.dump(self.c_commands, open(self.file_path, 'w+'))
-            await ctx.send("PAD **{}** successfully deleted.".format('alias' if alias else 'command'))
+            await ctx.send("PAD {} successfully deleted.".format('ALIAS' if alias else 'COMMAND'))
         else:
             await ctx.send("PAD command doesn't exist.")
 


### PR DESCRIPTION
Resolves #381.

* Prompts the user for confirmation if trying to delete a command with aliases.
* Adds more feedback to let the user know whether an alias or a command was just deleted.
* Fixes (prevents) this weird bug where aliasing something to itself not only deleted the content of the command but also made an infinite loop happen if trying to do something further with the command (e.g. put back the content).