### PR TITLE
Fix left-right arrows in MonsterListMenu

### DIFF
--- a/padinfo/menu/monster_list.py
+++ b/padinfo/menu/monster_list.py
@@ -237,7 +237,7 @@ class MonsterListMenu:
             'menu_type': IdMenu.MENU_TYPE,
             'resolved_monster_id':
                 monster_list[n - MonsterListMenuPanes.NON_MONSTER_EMOJI_COUNT].monster_id,
-            'resolved_monster_server': ims['monster_server'],
+            'resolved_monster_server': ims['resolved_monster_server'],
         }
         return emoji_response, extra_ims
 
@@ -257,11 +257,13 @@ class MonsterListMenu:
         paginated_monsters = await _get_view_state(ims).query_paginated_from_ims(dgcog, copy_ims)
         page = copy_ims.get('current_page') or 0
         monster_list = paginated_monsters[page]
+        monster = monster_list[copy_ims['current_index']]
         extra_ims = {
             'is_child': True,
             'reaction_list': IdMenuPanes.emoji_names(),
             'menu_type': IdMenu.MENU_TYPE,
-            'resolved_monster_id': monster_list[copy_ims['current_index']].monster_id,
+            'resolved_monster_id': monster.monster_id,
+            'resolved_monster_server': monster.server_priority,
         }
         return IdMenuEmoji.refresh, extra_ims
 

--- a/padinfo/view/monster_list/monster_list.py
+++ b/padinfo/view/monster_list/monster_list.py
@@ -48,7 +48,7 @@ class MonsterListViewState(ViewStateBase):
             'pane_type': MonsterListView.VIEW_TYPE,
             'title': self.title,
             'monster_list': [m.monster_id for m in self.monster_list],
-            'monster_server': self.monster_list[0].server_priority if self.monster_list else "COMBINED",
+            'resolved_monster_server': self.monster_list[0].server_priority if self.monster_list else "COMBINED",
             'current_page': self.current_page,
             'reaction_list': self.reaction_list,
             'child_message_id': self.child_message_id,

--- a/padinfo/view/monster_list/static_monster_list.py
+++ b/padinfo/view/monster_list/static_monster_list.py
@@ -14,7 +14,7 @@ class StaticMonsterListViewState(MonsterListViewState):
         ret = super().serialize()
         ret.update({
             'full_monster_list': [m.monster_id for page in self.paginated_monsters for m in page],
-            'monster_server': self.paginated_monsters[0].server_priority if self.paginated_monsters else "COMBINED",
+            'resolved_monster_server': self.paginated_monsters[0].server_priority if self.paginated_monsters else "COMBINED",
         })
         return ret
 
@@ -27,6 +27,6 @@ class StaticMonsterListViewState(MonsterListViewState):
     @classmethod
     async def query_from_ims(cls, dgcog, ims) -> List["MonsterModel"]:
         monster_ids = ims['full_monster_list']
-        server = ims['monster_server']
+        server = ims['resolved_monster_server']
         monster_list = await cls.query(dgcog, monster_ids, server)
         return monster_list


### PR DESCRIPTION
Resolves #1130

I'm not sure why there was ever any ims with just `monster_server` instead of `resolved_monster_server` so I made that consistent too