### PR TITLE
Fix evolist getting server_priority

### DIFF
--- a/padinfo/view/monster_list/static_monster_list.py
+++ b/padinfo/view/monster_list/static_monster_list.py
@@ -14,7 +14,8 @@ class StaticMonsterListViewState(MonsterListViewState):
         ret = super().serialize()
         ret.update({
             'full_monster_list': [m.monster_id for page in self.paginated_monsters for m in page],
-            'resolved_monster_server': self.paginated_monsters[0].server_priority if self.paginated_monsters else "COMBINED",
+            'resolved_monster_server': (self.paginated_monsters[0][0].server_priority
+                                        if self.paginated_monsters else "COMBINED"),
         })
         return ret
 


### PR DESCRIPTION
Fixes static MonsterListMenus not working (it was trying to get a server priority from a list of monsters).