### PR TITLE
Refactor seriesscroll

### DIFF
--- a/padinfo/menu/series_scroll.py
+++ b/padinfo/menu/series_scroll.py
@@ -68,14 +68,14 @@ class SeriesScrollMenu:
     async def respond_with_left(cls, message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
         view_state = await cls._get_view_state(ims, **data)
-        await view_state.decrement_page(dgcog, ims)
+        await view_state.decrement_page(dgcog)
         return SeriesScrollMenu.monster_list_control(view_state)
 
     @classmethod
     async def respond_with_right(cls, message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
         view_state = await cls._get_view_state(ims, **data)
-        await view_state.increment_page(dgcog, ims)
+        await view_state.increment_page(dgcog)
         return SeriesScrollMenu.monster_list_control(view_state)
 
     @classmethod
@@ -87,14 +87,14 @@ class SeriesScrollMenu:
     async def respond_with_previous_monster(cls, message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
         view_state = await cls._get_view_state(ims, **data)
-        await view_state.decrement_index(dgcog, ims)
+        await view_state.decrement_index(dgcog)
         return SeriesScrollMenu.monster_list_control(view_state)
 
     @classmethod
     async def respond_with_next_monster(cls, message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
         view_state = await cls._get_view_state(ims, **data)
-        await view_state.increment_index(dgcog, ims)
+        await view_state.increment_index(dgcog)
         return SeriesScrollMenu.monster_list_control(view_state)
 
     @staticmethod
@@ -178,17 +178,17 @@ class SeriesScrollMenu:
     async def auto_scroll_child_left(cls, ims, _emoji_clicked, **data):
         dgcog = data['dgcog']
         view_state = await cls._get_view_state(ims, **data)
-        return await SeriesScrollMenu._scroll_child(view_state, view_state.decrement_index, dgcog, ims)
+        return await SeriesScrollMenu._scroll_child(view_state, view_state.decrement_index, dgcog)
 
     @classmethod
     async def auto_scroll_child_right(cls, ims, _emoji_clicked, **data):
         dgcog = data['dgcog']
         view_state = await cls._get_view_state(ims, **data)
-        return await SeriesScrollMenu._scroll_child(view_state, view_state.increment_index, dgcog, ims)
+        return await SeriesScrollMenu._scroll_child(view_state, view_state.increment_index, dgcog)
 
     @staticmethod
-    async def _scroll_child(view_state: SeriesScrollViewState, update_fn, dgcog, ims: dict):
-        await update_fn(dgcog, ims)
+    async def _scroll_child(view_state: SeriesScrollViewState, update_fn, dgcog):
+        await update_fn(dgcog)
         extra_ims = view_state.get_serialized_child_extra_ims(IdMenuPanes.emoji_names(), IdMenu.MENU_TYPE)
         return IdMenuEmoji.refresh, extra_ims
 

--- a/padinfo/menu/series_scroll.py
+++ b/padinfo/menu/series_scroll.py
@@ -87,11 +87,12 @@ class SeriesScrollMenu:
         control = SeriesScrollMenu.monster_list_control(view_state)
         return control
 
-    @staticmethod
-    async def respond_with_previous_monster(message: Optional[Message], ims, **data):
+    @classmethod
+    async def respond_with_previous_monster(cls, message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
-        await SeriesScrollMenu._update_ims_prev(dgcog, ims)
-        return await SeriesScrollMenu.respond_with_monster_list(message, ims, **data)
+        view_state = await cls._get_view_state(ims, **data)
+        await view_state.decrement_index(dgcog, ims)
+        return SeriesScrollMenu.monster_list_control(view_state)
 
     @staticmethod
     async def _update_ims_prev(dgcog, ims):

--- a/padinfo/menu/series_scroll.py
+++ b/padinfo/menu/series_scroll.py
@@ -118,11 +118,12 @@ class SeriesScrollMenu:
             ims['current_page'] = len(paginated_monsters_new) - 1
             ims['current_index'] = len(paginated_monsters_new[-1]) - 1
 
-    @staticmethod
-    async def respond_with_next_monster(message: Optional[Message], ims, **data):
+    @classmethod
+    async def respond_with_next_monster(cls, message: Optional[Message], ims, **data):
         dgcog = data['dgcog']
-        await SeriesScrollMenu._update_ims_next(dgcog, ims)
-        return await SeriesScrollMenu.respond_with_monster_list(message, ims, **data)
+        view_state = await cls._get_view_state(ims, **data)
+        await view_state.increment_index(dgcog, ims)
+        return SeriesScrollMenu.monster_list_control(view_state)
 
     @staticmethod
     async def _update_ims_next(dgcog, ims):

--- a/padinfo/menu/series_scroll.py
+++ b/padinfo/menu/series_scroll.py
@@ -78,13 +78,10 @@ class SeriesScrollMenu:
         await view_state.increment_page(dgcog, ims)
         return SeriesScrollMenu.monster_list_control(view_state)
 
-    @staticmethod
-    async def respond_with_monster_list(message: Optional[Message], ims, **data):
-        dgcog = data['dgcog']
-        user_config = data['user_config']
-        view_state = await SeriesScrollViewState.deserialize(dgcog, user_config, ims)
-        control = SeriesScrollMenu.monster_list_control(view_state)
-        return control
+    @classmethod
+    async def respond_with_monster_list(cls, message: Optional[Message], ims, **data):
+        view_state = await cls._get_view_state(ims, **data)
+        return SeriesScrollMenu.monster_list_control(view_state)
 
     @classmethod
     async def respond_with_previous_monster(cls, message: Optional[Message], ims, **data):

--- a/padinfo/menu/series_scroll.py
+++ b/padinfo/menu/series_scroll.py
@@ -72,22 +72,12 @@ class SeriesScrollMenu:
         await view_state.decrement_page(dgcog, ims)
         return SeriesScrollMenu.monster_list_control(view_state)
 
-    @staticmethod
-    async def respond_with_right(message: Optional[Message], ims, **data):
-        paginated_monsters = await SeriesScrollViewState.query_from_ims(data['dgcog'], ims)
-        current_page = ims['current_page']
-        if current_page < len(paginated_monsters) - 1:
-            ims['current_page'] = current_page + 1
-            ims['current_index'] = None
-            return await SeriesScrollMenu.respond_with_monster_list(message, ims, **data)
-        current_rarity_index = ims['all_rarities'].index(ims['rarity'])
-        if current_rarity_index == len(ims['all_rarities']) - 1:
-            ims['rarity'] = ims['all_rarities'][0]
-        else:
-            ims['rarity'] = ims['all_rarities'][current_rarity_index + 1]
-        ims['current_page'] = 0
-        ims['current_index'] = None
-        return await SeriesScrollMenu.respond_with_monster_list(message, ims, **data)
+    @classmethod
+    async def respond_with_right(cls, message: Optional[Message], ims, **data):
+        dgcog = data['dgcog']
+        view_state = await cls._get_view_state(ims, **data)
+        await view_state.increment_page(dgcog, ims)
+        return SeriesScrollMenu.monster_list_control(view_state)
 
     @staticmethod
     async def respond_with_monster_list(message: Optional[Message], ims, **data):

--- a/padinfo/menu/series_scroll.py
+++ b/padinfo/menu/series_scroll.py
@@ -101,9 +101,13 @@ class SeriesScrollMenu:
     async def respond_with_delete(message: Message, ims, **data):
         return await message.delete()
 
-    @staticmethod
-    async def respond_with_n(message: Optional[Message], ims, n, **data):
-        ims['current_index'] = n
+    @classmethod
+    async def respond_with_n(cls, message: Optional[Message], ims, n, **data):
+        view_state = await cls._get_view_state(ims, **data)
+        current_monster_list = view_state.paginated_monsters[view_state.current_page]
+        # ims will be immediately be deserialized and shown, so don't change if n is out of range
+        if n < len(current_monster_list):
+            ims['current_index'] = n
         return await SeriesScrollMenu.respond_with_monster_list(message, ims, **data)
 
     @staticmethod

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -701,7 +701,7 @@ class PadInfo(commands.Cog):
         instruction_message = 'Click a reaction to see monster details!'
 
         state = SeriesScrollViewState(original_author_id, SeriesScrollMenu.MENU_TYPE, raw_query, query, color,
-                                      series_id, paginated_monsters, 0, int(rarity), len(paginated_monsters),
+                                      series_id, paginated_monsters, 0, int(rarity),
                                       query_settings,
                                       all_rarities,
                                       title, instruction_message,

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -672,9 +672,9 @@ class PadInfo(commands.Cog):
             # The user could delete the menu before we can do this
             pass
 
-    @commands.command(aliases=['seriesscroll', 'ss'])
+    @commands.command(aliases=['collabscroll', 'ss'])
     @checks.bot_has_permissions(embed_links=True)
-    async def collabscroll(self, ctx, *, query):
+    async def seriesscroll(self, ctx, *, query):
         dgcog = await self.get_dgcog()
         monster = await dgcog.find_monster(query, ctx.author.id)
 

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -701,7 +701,7 @@ class PadInfo(commands.Cog):
         instruction_message = 'Click a reaction to see monster details!'
 
         state = SeriesScrollViewState(original_author_id, SeriesScrollMenu.MENU_TYPE, raw_query, query, color,
-                                      series_id, 0, paginated_monsters[0], int(rarity), len(paginated_monsters),
+                                      series_id, paginated_monsters, 0, int(rarity), len(paginated_monsters),
                                       query_settings,
                                       all_rarities,
                                       title, instruction_message,

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -20,8 +20,9 @@ if TYPE_CHECKING:
 class SeriesScrollViewState(ViewStateBase):
     MAX_ITEMS_PER_PANE = 11
 
-    def __init__(self, original_author_id, menu_type, raw_query, query, color, series_id, current_page,
-                 monster_list: List["MonsterModel"], rarity: int, pages_in_rarity: int, query_settings: QuerySettings,
+    def __init__(self, original_author_id, menu_type, raw_query, query, color, series_id,
+                 paginated_monsters: List[List["MonsterModel"]], current_page, rarity: int, pages_in_rarity: int,
+                 query_settings: QuerySettings,
                  all_rarities: List[int],
                  title, message,
                  current_index: int = None,
@@ -33,6 +34,7 @@ class SeriesScrollViewState(ViewStateBase):
         self.pages_in_rarity = pages_in_rarity
         self.current_index = current_index
         self.all_rarities = all_rarities
+        self.paginated_monsters = paginated_monsters
         self.current_page = current_page or 0
         self.series_id = series_id
         self.rarity = rarity
@@ -40,11 +42,11 @@ class SeriesScrollViewState(ViewStateBase):
         self.message = message
         self.child_message_id = child_message_id
         self.title = title
-        self.monster_list = monster_list
         self.reaction_list = reaction_list
         self.color = color
         self.query = query
-        self.max_len_so_far = max(max_len_so_far or len(monster_list), len(self.monster_list))
+        monster_list = paginated_monsters[current_page]
+        self.max_len_so_far = max(max_len_so_far or len(monster_list), len(monster_list))
 
     def serialize(self):
         ret = super().serialize()
@@ -75,7 +77,6 @@ class SeriesScrollViewState(ViewStateBase):
         query_settings = QuerySettings.deserialize(ims.get('query_settings'))
         paginated_monsters = await SeriesScrollViewState.do_query(dgcog, series_id, rarity, query_settings.server)
         current_page = ims['current_page']
-        monster_list = paginated_monsters[current_page]
         title = ims['title']
 
         pages_in_rarity = len(paginated_monsters)
@@ -86,11 +87,12 @@ class SeriesScrollViewState(ViewStateBase):
         reaction_list = ims.get('reaction_list')
         child_message_id = ims.get('child_message_id')
         message = ims.get('message')
+        monster_list = paginated_monsters[current_page]
         max_len_so_far = max(ims['max_len_so_far'] or len(monster_list), len(monster_list))
         current_index = ims.get('current_index')
 
         return SeriesScrollViewState(original_author_id, menu_type, raw_query, query, user_config.color, series_id,
-                                     current_page, monster_list, rarity, pages_in_rarity, query_settings,
+                                     paginated_monsters, current_page, rarity, pages_in_rarity, query_settings,
                                      all_rarities,
                                      title, message,
                                      current_index=current_index,

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -206,7 +206,9 @@ class SeriesScrollViewState(ViewStateBase):
         self.current_index = 0
 
     def set_index(self, new_index: int):
-        self.current_index = new_index
+        # don't want to go out of range, which will forget current index, break next, and break prev
+        if new_index < len(self.monster_list):
+            self.current_index = new_index
 
 
 class SeriesScrollView:

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -25,6 +25,7 @@ class SeriesScrollViewState(ViewStateBase):
                  all_rarities: List[int],
                  title, message,
                  current_index: int = None,
+                 max_len_so_far: int = None,
                  reaction_list=None, extra_state=None,
                  child_message_id=None):
         super().__init__(original_author_id, menu_type, raw_query,
@@ -42,14 +43,15 @@ class SeriesScrollViewState(ViewStateBase):
         self.reaction_list = reaction_list
         self.color = color
         self.query = query
+        current_monster_list = paginated_monsters[current_page]
+        self.max_len_so_far = max(max_len_so_far or len(current_monster_list), len(self.monster_list))
+
+    def _update_max_len(self):
+        self.max_len_so_far = max(self.max_len_so_far or len(self.monster_list), len(self.monster_list))
 
     @property
     def monster_list(self) -> List["MonsterModel"]:
         return self.paginated_monsters[self.current_page]
-
-    @property
-    def max_len_so_far(self) -> int:
-        return len(self.monster_list)
 
     @property
     def current_monster_id(self) -> int:
@@ -109,6 +111,8 @@ class SeriesScrollViewState(ViewStateBase):
         child_message_id = ims.get('child_message_id')
         message = ims.get('message')
         current_index = ims.get('current_index')
+        current_monster_list = paginated_monsters[current_page]
+        max_len_so_far = max(ims['max_len_so_far'] or len(current_monster_list), len(current_monster_list))
         idle_message = ims.get('idle_message')
 
         return SeriesScrollViewState(original_author_id, menu_type, raw_query, query, user_config.color, series_id,
@@ -116,6 +120,7 @@ class SeriesScrollViewState(ViewStateBase):
                                      all_rarities,
                                      title, idle_message,
                                      current_index=current_index,
+                                     max_len_so_far=max_len_so_far,
                                      reaction_list=reaction_list,
                                      extra_state=ims,
                                      child_message_id=child_message_id)
@@ -159,6 +164,7 @@ class SeriesScrollViewState(ViewStateBase):
                 self.current_index = None
             self.current_page = len(self.paginated_monsters) - 1
 
+        self._update_max_len()
         if len(self.paginated_monsters) > 1:
             self.current_index = None
 
@@ -176,6 +182,7 @@ class SeriesScrollViewState(ViewStateBase):
                 self.current_index = None
             self.current_page = 0
 
+        self._update_max_len()
         if len(self.paginated_monsters) > 1:
             self.current_index = None
 

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -36,7 +36,7 @@ class SeriesScrollViewState(ViewStateBase):
         self.series_id = series_id
         self.rarity = rarity
         self.query_settings = query_settings
-        self.message = message
+        self.idle_message = message
         self.child_message_id = child_message_id
         self.title = title
         self.reaction_list = reaction_list
@@ -72,7 +72,7 @@ class SeriesScrollViewState(ViewStateBase):
             'all_rarities': self.all_rarities,
             'reaction_list': self.reaction_list,
             'child_message_id': self.child_message_id,
-            'message': self.message,
+            'idle_message': self.idle_message,
             'max_len_so_far': self.max_len_so_far,
             'current_index': self.current_index,
         })
@@ -84,7 +84,8 @@ class SeriesScrollViewState(ViewStateBase):
             'reaction_list': emoji_names,
             'menu_type': menu_type,
             'resolved_monster_id': self.current_monster_id,
-            'query_settings': self.query_settings.serialize()
+            'query_settings': self.query_settings.serialize(),
+            'idle_message': self.idle_message
         }
         return extra_ims
 
@@ -108,11 +109,12 @@ class SeriesScrollViewState(ViewStateBase):
         child_message_id = ims.get('child_message_id')
         message = ims.get('message')
         current_index = ims.get('current_index')
+        idle_message = ims.get('idle_message')
 
         return SeriesScrollViewState(original_author_id, menu_type, raw_query, query, user_config.color, series_id,
                                      paginated_monsters, current_page, rarity, query_settings,
                                      all_rarities,
-                                     title, message,
+                                     title, idle_message,
                                      current_index=current_index,
                                      reaction_list=reaction_list,
                                      extra_state=ims,

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -5,7 +5,6 @@ from discordmenu.embed.components import EmbedMain, EmbedField
 from discordmenu.embed.text import BoldText
 from discordmenu.embed.view import EmbedView
 from tsutils import char_to_emoji, embed_footer_with_state
-from tsutils.enums import Server
 from tsutils.query_settings import QuerySettings
 
 from padinfo.common.config import UserConfig

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -131,7 +131,7 @@ class SeriesScrollViewState(ViewStateBase):
             self.current_page = self.current_page - 1
             self.current_index = None
         else:
-            # if there are multiple rarities, decrementing 0th page will change rarity (and monsters)
+            # if there are multiple rarities, decrementing first page will change rarity
             if len(self.all_rarities) > 1:
                 rarity_index = self.all_rarities.index(self.rarity)
                 self.rarity = self.all_rarities[rarity_index - 1]
@@ -140,6 +140,26 @@ class SeriesScrollViewState(ViewStateBase):
                 self.pages_in_rarity = len(self.paginated_monsters)
                 self.current_index = None
             self.current_page = len(self.paginated_monsters) - 1
+
+        self.monster_list = self.paginated_monsters[self.current_page]
+        self.max_len_so_far = len(self.monster_list)
+        if len(self.paginated_monsters) > 1:
+            self.current_index = None
+
+    async def increment_page(self, dgcog, ims: dict):
+        if self.current_page < len(self.paginated_monsters) - 1:
+            self.current_page = self.current_page + 1
+            self.current_index = None
+        else:
+            # if there are multiple rarities, incrementing last page will change rarity
+            if len(self.all_rarities) > 1:
+                rarity_index = self.all_rarities.index(self.rarity)
+                self.rarity = self.all_rarities[(rarity_index + 1) % len(self.all_rarities)]
+                self.paginated_monsters = await SeriesScrollViewState.do_query(dgcog, self.series_id, self.rarity,
+                                                                               self.query_settings.server)
+                self.pages_in_rarity = len(self.paginated_monsters)
+                self.current_index = None
+            self.current_page = 0
 
         self.monster_list = self.paginated_monsters[self.current_page]
         self.max_len_so_far = len(self.monster_list)

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -176,6 +176,16 @@ class SeriesScrollViewState(ViewStateBase):
         await self.decrement_page(dgcog, ims)
         self.current_index = len(self.monster_list) - 1
 
+    async def increment_index(self, dgcog, ims: dict):
+        if self.current_index is None:
+            self.current_index = 0
+            return
+        if self.current_index < len(self.monster_list) - 1:
+            self.current_index = self.current_index + 1
+            return
+        await self.increment_page(dgcog, ims)
+        self.current_index = 0
+
 
 class SeriesScrollView:
     VIEW_TYPE = 'SeriesScroll'

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -166,6 +166,17 @@ class SeriesScrollViewState(ViewStateBase):
         if len(self.paginated_monsters) > 1:
             self.current_index = None
 
+    async def decrement_index(self, dgcog, ims: dict):
+        if self.current_index is None:
+            self.current_index = len(self.monster_list) - 1
+            return
+        if self.current_index > 0:
+            self.current_index = self.current_index - 1
+            return
+        await self.decrement_page(dgcog, ims)
+        self.current_index = len(self.monster_list) - 1
+
+
 class SeriesScrollView:
     VIEW_TYPE = 'SeriesScroll'
 

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -149,7 +149,7 @@ class SeriesScrollViewState(ViewStateBase):
         paginated_monsters = await SeriesScrollViewState.do_query(dgcog, series_id, rarity, query_settings.server)
         return paginated_monsters
 
-    async def decrement_page(self, dgcog, ims: dict):
+    async def decrement_page(self, dgcog):
         if self.current_page > 0:
             self.current_page = self.current_page - 1
             self.current_index = None
@@ -167,7 +167,7 @@ class SeriesScrollViewState(ViewStateBase):
         if len(self.paginated_monsters) > 1:
             self.current_index = None
 
-    async def increment_page(self, dgcog, ims: dict):
+    async def increment_page(self, dgcog):
         if self.current_page < len(self.paginated_monsters) - 1:
             self.current_page = self.current_page + 1
             self.current_index = None
@@ -185,7 +185,7 @@ class SeriesScrollViewState(ViewStateBase):
         if len(self.paginated_monsters) > 1:
             self.current_index = None
 
-    async def decrement_index(self, dgcog, ims: dict):
+    async def decrement_index(self, dgcog):
         if self.current_index is None:
             self.current_index = len(self.monster_list) - 1
             return
@@ -195,7 +195,7 @@ class SeriesScrollViewState(ViewStateBase):
         await self.decrement_page(dgcog, ims)
         self.current_index = len(self.monster_list) - 1
 
-    async def increment_index(self, dgcog, ims: dict):
+    async def increment_index(self, dgcog):
         if self.current_index is None:
             self.current_index = 0
             return

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -53,6 +53,10 @@ class SeriesScrollViewState(ViewStateBase):
         return len(self.monster_list)
 
     @property
+    def current_monster_id(self) -> int:
+        return self.monster_list[self.current_index].monster_id
+
+    @property
     def pages_in_rarity(self) -> int:
         return len(self.paginated_monsters)
 
@@ -74,6 +78,16 @@ class SeriesScrollViewState(ViewStateBase):
             'current_index': self.current_index,
         })
         return ret
+
+    def get_serialized_child_extra_ims(self, emoji_names, menu_type):
+        extra_ims = {
+            'is_child': True,
+            'reaction_list': emoji_names,
+            'menu_type': menu_type,
+            'resolved_monster_id': self.current_monster_id,
+            'query_settings': self.query_settings.serialize()
+        }
+        return extra_ims
 
     @staticmethod
     async def deserialize(dgcog, user_config: UserConfig, ims: dict):
@@ -183,6 +197,9 @@ class SeriesScrollViewState(ViewStateBase):
             return
         await self.increment_page(dgcog, ims)
         self.current_index = 0
+
+    def set_index(self, new_index: int):
+        self.current_index = new_index
 
 
 class SeriesScrollView:

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -109,7 +109,6 @@ class SeriesScrollViewState(ViewStateBase):
         menu_type = ims['menu_type']
         reaction_list = ims.get('reaction_list')
         child_message_id = ims.get('child_message_id')
-        message = ims.get('message')
         current_index = ims.get('current_index')
         current_monster_list = paginated_monsters[current_page]
         max_len_so_far = max(ims['max_len_so_far'] or len(current_monster_list), len(current_monster_list))

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -43,15 +43,16 @@ class SeriesScrollViewState(ViewStateBase):
         self.reaction_list = reaction_list
         self.color = color
         self.query = query
-        current_monster_list = paginated_monsters[current_page]
-        self.max_len_so_far = max(max_len_so_far or len(current_monster_list), len(self.monster_list))
-
-    def _update_max_len(self):
-        self.max_len_so_far = max(self.max_len_so_far or len(self.monster_list), len(self.monster_list))
+        self._max_len_so_far = max(max_len_so_far or len(self.monster_list), len(self.monster_list))
 
     @property
     def monster_list(self) -> List["MonsterModel"]:
         return self.paginated_monsters[self.current_page]
+
+    @property
+    def max_len_so_far(self) -> int:
+        self._max_len_so_far = max(len(self.monster_list), self._max_len_so_far)
+        return self._max_len_so_far
 
     @property
     def current_monster_id(self) -> int:
@@ -163,7 +164,6 @@ class SeriesScrollViewState(ViewStateBase):
                 self.current_index = None
             self.current_page = len(self.paginated_monsters) - 1
 
-        self._update_max_len()
         if len(self.paginated_monsters) > 1:
             self.current_index = None
 
@@ -181,7 +181,6 @@ class SeriesScrollViewState(ViewStateBase):
                 self.current_index = None
             self.current_page = 0
 
-        self._update_max_len()
         if len(self.paginated_monsters) > 1:
             self.current_index = None
 

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -126,6 +126,25 @@ class SeriesScrollViewState(ViewStateBase):
         paginated_monsters = await SeriesScrollViewState.do_query(dgcog, series_id, rarity, query_settings.server)
         return paginated_monsters
 
+    async def decrement_page(self, dgcog, ims: dict):
+        if self.current_page > 0:
+            self.current_page = self.current_page - 1
+            self.current_index = None
+        else:
+            # if there are multiple rarities, decrementing 0th page will change rarity (and monsters)
+            if len(self.all_rarities) > 1:
+                rarity_index = self.all_rarities.index(self.rarity)
+                self.rarity = self.all_rarities[rarity_index - 1]
+                self.paginated_monsters = await SeriesScrollViewState.do_query(dgcog, self.series_id, self.rarity,
+                                                                               self.query_settings.server)
+                self.pages_in_rarity = len(self.paginated_monsters)
+                self.current_index = None
+            self.current_page = len(self.paginated_monsters) - 1
+
+        self.monster_list = self.paginated_monsters[self.current_page]
+        self.max_len_so_far = len(self.monster_list)
+        if len(self.paginated_monsters) > 1:
+            self.current_index = None
 
 class SeriesScrollView:
     VIEW_TYPE = 'SeriesScroll'

--- a/padinfo/view/series_scroll.py
+++ b/padinfo/view/series_scroll.py
@@ -45,8 +45,8 @@ class SeriesScrollViewState(ViewStateBase):
         self.reaction_list = reaction_list
         self.color = color
         self.query = query
-        monster_list = paginated_monsters[current_page]
-        self.max_len_so_far = max(max_len_so_far or len(monster_list), len(monster_list))
+        self.monster_list = paginated_monsters[current_page]
+        self.max_len_so_far = max(max_len_so_far or len(self.monster_list), len(self.monster_list))
 
     def serialize(self):
         ret = super().serialize()


### PR DESCRIPTION
Resolves #1169.

* Refactors seriesscroll as #1168 and #1181 refactored monsterlist, i.e. uses methods on the view state to change the embed instead of modifying the ims directly.
* Makes `[p]collabscroll` the alias and `[p]seriesscroll` the command since that makes more sense and is more broadly applicable. (Also the view/menu classes have SeriesScroll in their names anyway.)
* Fixes a bug where seriesscroll child menus were not deleting.
* Also fixes a bug where clicking a child emoji that's out of range forgot current index and broke things.