### PR TITLE
Make buttoninfo an embed & visual improvements

### DIFF
--- a/dadguide/models/monster_stats.py
+++ b/dadguide/models/monster_stats.py
@@ -77,12 +77,10 @@ class MonsterStats:
             s_val += inherit_bonus.get_awakening_addition(key)
 
         if multiplayer:
-            print(s_val)
             num_multiboost = monster_model.awakening_count(AwokenSkills.MULTIBOOST.value)
             num_multiboost += inherited_monster.awakening_count(
                 AwokenSkills.MULTIBOOST.value) if inherited_monster else 0
             s_val = round(round(s_val) * (1.5 ** num_multiboost))
-            print(s_val)
 
         return s_val
 

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -27,16 +27,17 @@ CARD_BUTTON_FORMAT = "[{}] {} ({}x): {}"
 MonsterStat = namedtuple('MonsterStat', 'name id mult att')
 
 TEAM_BUTTONS = [
+    # account for attributes when spacing
     MonsterStat("Nergi Hunter", 4172, 40, [2, 4]),
-    MonsterStat("Oversoul", 5273, 50, [0, 1, 2, 3, 4]),
-    MonsterStat("Ryuno Ume", 5252, 80, [2, 4])
+    MonsterStat("Oversoul ", 5273, 50, [0, 1, 2, 3, 4]),
+    MonsterStat("Ryuno Ume   ", 5252, 80, [2, 4])
 ]
 CARD_BUTTONS = [
-    MonsterStat("Satan", 4286, 300, []),
-    MonsterStat("Durandalf Equip", 4723, 300, []),
+    MonsterStat("Satan           ", 4286, 300, []),
+    MonsterStat("Durandalf Equip ", 4723, 300, []),
     MonsterStat("Brachydios Equip", 4152, 350, []),
-    MonsterStat("Rajang", 5527, 550, []),
-    MonsterStat("Balrog", 5108, 450, [])
+    MonsterStat("Rajang          ", 5527, 550, []),
+    MonsterStat("Balrog          ", 5108, 450, [])
 ]
 
 COLORS = ["R", "B", "G", "L", "D"]

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -36,7 +36,7 @@ CARD_BUTTONS = [
     MonsterStat("Satan{}        ", 4286, 300, []),
     MonsterStat("Durandalf Eq{} ", 4723, 300, []),
     MonsterStat("Brachydios Eq{}", 4152, 350, []),
-    MonsterStat("Rajang{}       ", 5527, 550, []),
+    MonsterStat("Rajang Eq{}    ", 5530, 550, []),
     MonsterStat("Balrog{}       ", 5108, 450, [])
 ]
 

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -28,19 +28,20 @@ MonsterStat = namedtuple('MonsterStat', 'name id mult att')
 
 TEAM_BUTTONS = [
     # account for attributes when spacing
-    MonsterStat("Nergi Hunter", 4172, 40, [2, 4]),
-    MonsterStat("Oversoul ", 5273, 50, [0, 1, 2, 3, 4]),
-    MonsterStat("Ryuno Ume   ", 5252, 80, [2, 4])
+    MonsterStat("Nergi Hunter{}", 4172, 40, [2, 4]),
+    MonsterStat("Oversoul{} ", 5273, 50, [0, 1, 2, 3, 4]),
+    MonsterStat("Ryuno Ume{}   ", 5252, 80, [2, 4])
 ]
 CARD_BUTTONS = [
-    MonsterStat("Satan        ", 4286, 300, []),
-    MonsterStat("Durandalf Eq ", 4723, 300, []),
-    MonsterStat("Brachydios Eq", 4152, 350, []),
-    MonsterStat("Rajang       ", 5527, 550, []),
-    MonsterStat("Balrog       ", 5108, 450, [])
+    MonsterStat("Satan{}        ", 4286, 300, []),
+    MonsterStat("Durandalf Eq{} ", 4723, 300, []),
+    MonsterStat("Brachydios Eq{}", 4152, 350, []),
+    MonsterStat("Rajang{}       ", 5527, 550, []),
+    MonsterStat("Balrog{}       ", 5108, 450, [])
 ]
 
 COLORS = ["R", "B", "G", "L", "D"]
+NIL_ATT = 'Nil'
 
 
 class ButtonInfo:
@@ -117,12 +118,12 @@ class ButtonInfo:
             stat_latents = dgcog.MonsterStatModifierInput(num_atkpp=monster.latent_slots / 2)
             dmg = int(round(dgcog.monster_stats.stat(monster, 'atk', max_level, stat_latents=stat_latents,
                       inherited_monster=inherit_model, multiplayer=True, inherited_monster_lvl=inherit_max_level)))
+            oncolor = '*' if monster.attr1.value == inherit_model.attr1.value or monster.attr1.name == NIL_ATT else ' '
             lines.append(CARD_BUTTON_FORMAT.format(
-                card.id, card.name, card.mult, round(dmg * card.mult, 2)))
+                card.id, card.name.format(oncolor), card.mult, round(dmg * card.mult, 2)))
         return "\n".join(lines)
 
     def _get_team_btn_damage(self, team_buttons, dgcog, monster):
-        # TODO: calculate with oncolor assist damage and ATK+ eq (Oversoul)
         lines = []
         team_buttons.sort(key=lambda x: x.mult)
         for card in team_buttons:
@@ -140,7 +141,8 @@ class ButtonInfo:
             colors_str = ""
             for i in card.att:
                 colors_str += COLORS[i]
-            lines.append(TEAM_BUTTON_FORMAT.format(card.id, card.name,
+            oncolor = '*' if monster.attr1.value == inherit_model.attr1.value or monster.attr1.name == NIL_ATT else ' '
+            lines.append(TEAM_BUTTON_FORMAT.format(card.id, card.name.format(oncolor),
                          card.mult, colors_str, round(total_dmg * card.mult, 2)))
         return "\n".join(lines)
 

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -33,11 +33,11 @@ TEAM_BUTTONS = [
     MonsterStat("Ryuno Ume   ", 5252, 80, [2, 4])
 ]
 CARD_BUTTONS = [
-    MonsterStat("Satan           ", 4286, 300, []),
-    MonsterStat("Durandalf Equip ", 4723, 300, []),
-    MonsterStat("Brachydios Equip", 4152, 350, []),
-    MonsterStat("Rajang          ", 5527, 550, []),
-    MonsterStat("Balrog          ", 5108, 450, [])
+    MonsterStat("Satan        ", 4286, 300, []),
+    MonsterStat("Durandalf Eq ", 4723, 300, []),
+    MonsterStat("Brachydios Eq", 4152, 350, []),
+    MonsterStat("Rajang       ", 5527, 550, []),
+    MonsterStat("Balrog       ", 5108, 450, [])
 ]
 
 COLORS = ["R", "B", "G", "L", "D"]

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -76,6 +76,8 @@ class ButtonInfo:
             dgcog, monster_model, max_level, max_atk_latents)
         result.sub_damage_with_atk_latent = result.main_damage_with_atk_latent * sub_attr_multiplier
         result.total_damage_with_atk_latent = result.main_damage_with_atk_latent + result.sub_damage_with_atk_latent
+        result.card_btn_str = self._get_card_btn_damage(CARD_BUTTONS, dgcog, monster_model)
+        result.team_btn_str = self._get_team_btn_damage(TEAM_BUTTONS, dgcog, monster_model)
         return result
 
     def _calculate_damage(self, dgcog, monster_model, level, num_atkpp_latent=0):

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -118,7 +118,7 @@ class ButtonInfo:
             dmg = int(round(dgcog.monster_stats.stat(monster, 'atk', max_level, stat_latents=stat_latents,
                       inherited_monster=inherit_model, multiplayer=True, inherited_monster_lvl=inherit_max_level)))
             lines.append(CARD_BUTTON_FORMAT.format(
-                card.id, card.name, card.mult, (dmg * card.mult)))
+                card.id, card.name, card.mult, round(dmg * card.mult, 2)))
         return "\n".join(lines)
 
     def _get_team_btn_damage(self, team_buttons, dgcog, monster):
@@ -141,7 +141,7 @@ class ButtonInfo:
             for i in card.att:
                 colors_str += COLORS[i]
             lines.append(TEAM_BUTTON_FORMAT.format(card.id, card.name,
-                         card.mult, colors_str, (total_dmg * card.mult)))
+                         card.mult, colors_str, round(total_dmg * card.mult, 2)))
         return "\n".join(lines)
 
 

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -21,8 +21,8 @@ Inherits are assumed to be the max possible level (up to 110) and +297
 {}
 """
 
-TEAM_BUTTON_FORMAT = "As [{}] {} base ({}x {}): Contributes {}"
-CARD_BUTTON_FORMAT = "As [{}] {} base ({}x): Deals {}"
+TEAM_BUTTON_FORMAT = "[{}] {} ({}x {}): {}"
+CARD_BUTTON_FORMAT = "[{}] {} ({}x): {}"
 
 MonsterStat = namedtuple('MonsterStat', 'name id mult att')
 

--- a/padinfo/menu/closable_embed.py
+++ b/padinfo/menu/closable_embed.py
@@ -3,11 +3,13 @@ from discordmenu.embed.menu import EmbedMenu
 
 from tsutils.menu.panes import MenuPanes
 from padinfo.view.awakening_help import AwakeningHelpView
+from padinfo.view.button_info import ButtonInfoView
 from padinfo.view.closable_embed import ClosableEmbedViewState
 from padinfo.view.id_traceback import IdTracebackView
 
 view_types = {
     AwakeningHelpView.VIEW_TYPE: AwakeningHelpView,
+    ButtonInfoView.VIEW_TYPE: ButtonInfoView,
     IdTracebackView.VIEW_TYPE: IdTracebackView,
 }
 

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -40,6 +40,7 @@ from padinfo.menu.transforminfo import TransformInfoMenu, TransformInfoMenuPanes
 from padinfo.reaction_list import get_id_menu_initial_reaction_list
 from padinfo.view.awakening_help import AwakeningHelpView, AwakeningHelpViewProps
 from padinfo.view.awakening_list import AwakeningListViewState, AwakeningListSortTypes
+from padinfo.view.button_info import ButtonInfoView, ButtonInfoViewProps
 from padinfo.view.closable_embed import ClosableEmbedViewState
 from padinfo.view.common import invalid_monster_text
 from padinfo.view.components.monster.header import MonsterHeader
@@ -581,8 +582,13 @@ class PadInfo(commands.Cog):
 
         info = button_info.get_info(dgcog, monster)
         info_str = button_info.to_string(dgcog, monster, info)
-        for page in pagify(info_str):
-            await ctx.send(box(page))
+        original_author_id = ctx.message.author.id
+        menu = ClosableEmbedMenu.menu()
+        color = await self.get_user_embed_color(ctx)
+        props = ButtonInfoViewProps(result=info_str)
+        state = ClosableEmbedViewState(original_author_id, ClosableEmbedMenu.MENU_TYPE, query,
+                                       color, ButtonInfoView.VIEW_TYPE, props)
+        await menu.create(ctx, state)
 
     @commands.command()
     @checks.bot_has_permissions(embed_links=True)

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -581,11 +581,10 @@ class PadInfo(commands.Cog):
             return
 
         info = button_info.get_info(dgcog, monster)
-        info_str = button_info.to_string(dgcog, monster, info)
         original_author_id = ctx.message.author.id
         menu = ClosableEmbedMenu.menu()
         color = await self.get_user_embed_color(ctx)
-        props = ButtonInfoViewProps(monster=monster, result=info_str)
+        props = ButtonInfoViewProps(monster=monster, info=info)
         state = ClosableEmbedViewState(original_author_id, ClosableEmbedMenu.MENU_TYPE, query,
                                        color, ButtonInfoView.VIEW_TYPE, props)
         await menu.create(ctx, state)

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -585,7 +585,7 @@ class PadInfo(commands.Cog):
         original_author_id = ctx.message.author.id
         menu = ClosableEmbedMenu.menu()
         color = await self.get_user_embed_color(ctx)
-        props = ButtonInfoViewProps(result=info_str)
+        props = ButtonInfoViewProps(monster=monster, result=info_str)
         state = ClosableEmbedViewState(original_author_id, ClosableEmbedMenu.MENU_TYPE, query,
                                        color, ButtonInfoView.VIEW_TYPE, props)
         await menu.create(ctx, state)

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -54,10 +54,18 @@ class ButtonInfoView:
             EmbedField('With Latents', get_stats_with_latents(info)),
             EmbedField(
                 'Common Buttons',
-                Text('Inherits are assumed to be the max possible level (up to 110) and +297')
-            ),
-            EmbedField('Card Button Damage', BlockText(info.card_btn_str)),
-            EmbedField('Team Button Contribution', BlockText(info.team_btn_str))
+                Box(
+                    Text('*Inherits are assumed to be the max possible level (up to 110) and +297*'),
+                    Text('Card Button Damage'),
+                    # done this way to not have the whitespace after code block
+                    Box(
+                        BlockText(info.card_btn_str),
+                        Text('Team Button Contribution'),
+                        delimiter=''
+                    ),
+                    BlockText(info.team_btn_str)
+                )
+            )
         ]
 
         return EmbedView(

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -55,7 +55,8 @@ class ButtonInfoView:
             EmbedField(
                 'Common Buttons',
                 Box(
-                    Text('*Inherits are assumed to be the max possible level (up to 110) and +297*'),
+                    Text('*Inherits are assumed to be the max possible level (up to 110) and +297.*'),
+                    Text('*\* = on-color stat bonus applied*'),
                     Text('Card Button Damage'),
                     # done this way to not have the whitespace after code block
                     Box(

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -56,7 +56,8 @@ class ButtonInfoView:
                 'Common Buttons',
                 Box(
                     Text('*Inherits are assumed to be the max possible level (up to 110) and +297.*'),
-                    Text('*\* = on-color stat bonus applied*'),
+                    # janky, but python gives DeprecationWarnings when using \*
+                    Text('*' + r'\* = on-color stat bonus applied' + '*'),
                     Text('Card Button Damage'),
                     # done this way to not have the whitespace after code block
                     Box(

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -56,8 +56,8 @@ class ButtonInfoView:
                 'Common Buttons',
                 Box(
                     Text('*Inherits are assumed to be the max possible level (up to 110) and +297.*'),
-                    # janky, but python gives DeprecationWarnings when using \*
-                    Text('*' + r'\* = on-color stat bonus applied' + '*'),
+                    # janky, but python gives DeprecationWarnings when using \* in a regular string
+                    Text(r'*\* = on-color stat bonus applied*'),
                     Text('Card Button Damage'),
                     # done this way to not have the whitespace after code block
                     Box(

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -53,7 +53,7 @@ class ButtonInfoView:
             EmbedField('Without Latents', get_stats_without_latents(info)),
             EmbedField('With Latents', get_stats_with_latents(info)),
             EmbedField(
-                'Damage From Common Buttons',
+                'Common Buttons',
                 Text('Inherits are assumed to be the max possible level (up to 110) and +297')
             ),
             EmbedField('Card Button Damage', BlockText(info.card_btn_str)),

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -1,11 +1,29 @@
-from discordmenu.embed.components import EmbedField, EmbedMain
+from typing import TYPE_CHECKING
+
+from discordmenu.embed.components import EmbedAuthor, EmbedField, EmbedMain
 from discordmenu.embed.text import Text
 from discordmenu.embed.view import EmbedView
 from tsutils import embed_footer_with_state
 
+from padinfo.common.external_links import puzzledragonx
+from padinfo.view.components.monster.header import MonsterHeader
+from padinfo.view.components.monster.image import MonsterImage
+
+if TYPE_CHECKING:
+    from dadguide.models.monster_model import MonsterModel
+
+
 class ButtonInfoViewProps:
-    def __init__(self, result):
-        self.result = result
+    def __init__(self, monster: "MonsterModel", result):
+        self.monster = monster
+        self.info_str = result
+        # TODO: use the actual result object rather than the raw string
+        # self.main_damage = result.main_damage
+        # self.total_damage = result.total_damage
+        # self.sub_damage = result.sub_damage
+        # self.main_damage_with_atk_latent = result.main_damage_with_atk_latent
+        # self.total_damage_with_atk_latent = result.total_damage_with_atk_latent
+        # self.sub_damage_with_atk_latent = result.sub_damage_with_atk_latent
 
 
 class ButtonInfoView:
@@ -13,7 +31,8 @@ class ButtonInfoView:
 
     @staticmethod
     def embed(state, props: ButtonInfoViewProps):
-        info_str = props.result
+        monster = props.monster
+        info_str = props.info_str
 
         fields = [
             EmbedField('Info', Text(info_str))
@@ -22,7 +41,12 @@ class ButtonInfoView:
         return EmbedView(
             EmbedMain(
                 color=state.color,
-                title='Button Info'
+                description='(Co-op mode)'
+            ),
+            embed_author=EmbedAuthor(
+                MonsterHeader.long_v2(monster).to_markdown(),
+                puzzledragonx(monster),
+                MonsterImage.icon(monster)
             ),
             embed_footer=embed_footer_with_state(state),
             embed_fields=fields

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -56,8 +56,8 @@ class ButtonInfoView:
                 'Damage From Common Buttons',
                 Text('Inherits are assumed to be the max possible level (up to 110) and +297')
             ),
-            EmbedField('Card Buttons', Box(info.card_btn_str)),
-            EmbedField('Team Buttons', Box(info.team_btn_str))
+            EmbedField('Card Button Damage', Box(info.card_btn_str)),
+            EmbedField('Team Button Contribution', Box(info.team_btn_str))
         ]
 
         return EmbedView(

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedAuthor, EmbedField, EmbedMain
-from discordmenu.embed.text import Text
+from discordmenu.embed.text import Text, BlockText
 from discordmenu.embed.view import EmbedView
 from tsutils import embed_footer_with_state
 
@@ -22,18 +22,22 @@ class ButtonInfoViewProps:
 
 
 def get_stats_without_latents(info):
-    return Box(
-        Text('Base: {}'.format(int(round(info.main_damage)))),
-        Text('Subattr: {}'.format(int(round(info.sub_damage)))),
-        Text('Total: {}'.format(int(round(info.total_damage))))
+    return BlockText(
+        Box(
+            Text('Base:    {}'.format(int(round(info.main_damage)))),
+            Text('Subattr: {}'.format(int(round(info.sub_damage)))),
+            Text('Total:   {}'.format(int(round(info.total_damage))))
+        )
     )
 
 
 def get_stats_with_latents(info):
-    return Box(
-        Text('Base: {}'.format(int(round(info.main_damage_with_atk_latent)))),
-        Text('Subattr: {}'.format(int(round(info.sub_damage_with_atk_latent)))),
-        Text('Total: {}'.format(int(round(info.total_damage_with_atk_latent))))
+    return BlockText(
+        Box(
+            Text('Base:    {}'.format(int(round(info.main_damage_with_atk_latent)))),
+            Text('Subattr: {}'.format(int(round(info.sub_damage_with_atk_latent)))),
+            Text('Total:   {}'.format(int(round(info.total_damage_with_atk_latent))))
+        )
     )
 
 

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -1,11 +1,13 @@
 from typing import TYPE_CHECKING
 
+from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedAuthor, EmbedField, EmbedMain
 from discordmenu.embed.text import Text
 from discordmenu.embed.view import EmbedView
 from tsutils import embed_footer_with_state
 
 from padinfo.common.external_links import puzzledragonx
+from padinfo.core.button_info import button_info
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
 
@@ -14,16 +16,32 @@ if TYPE_CHECKING:
 
 
 class ButtonInfoViewProps:
-    def __init__(self, monster: "MonsterModel", result):
+    def __init__(self, monster: "MonsterModel", info):
         self.monster = monster
-        self.info_str = result
-        # TODO: use the actual result object rather than the raw string
+        self.info = info
+        # TODO: probably won't use these
         # self.main_damage = result.main_damage
-        # self.total_damage = result.total_damage
         # self.sub_damage = result.sub_damage
+        # self.total_damage = result.total_damage
         # self.main_damage_with_atk_latent = result.main_damage_with_atk_latent
-        # self.total_damage_with_atk_latent = result.total_damage_with_atk_latent
         # self.sub_damage_with_atk_latent = result.sub_damage_with_atk_latent
+        # self.total_damage_with_atk_latent = result.total_damage_with_atk_latent
+
+
+def get_stats_without_latents(info):
+    return Box(
+        Text('Base: {}'.format(int(round(info.main_damage)))),
+        Text('Subattr: {}'.format(int(round(info.sub_damage)))),
+        Text('Total: {}'.format(int(round(info.total_damage))))
+    )
+
+
+def get_stats_with_latents(info):
+    return Box(
+        Text('Base: {}'.format(int(round(info.main_damage_with_atk_latent)))),
+        Text('Subattr: {}'.format(int(round(info.sub_damage_with_atk_latent)))),
+        Text('Total: {}'.format(int(round(info.total_damage_with_atk_latent))))
+    )
 
 
 class ButtonInfoView:
@@ -32,10 +50,11 @@ class ButtonInfoView:
     @staticmethod
     def embed(state, props: ButtonInfoViewProps):
         monster = props.monster
-        info_str = props.info_str
+        info = props.info
 
         fields = [
-            EmbedField('Info', Text(info_str))
+            EmbedField('Without Latents', get_stats_without_latents(info)),
+            EmbedField('With Latents', get_stats_with_latents(info)),
         ]
 
         return EmbedView(

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -56,8 +56,8 @@ class ButtonInfoView:
                 'Damage From Common Buttons',
                 Text('Inherits are assumed to be the max possible level (up to 110) and +297')
             ),
-            EmbedField('Card Button Damage', Box(info.card_btn_str)),
-            EmbedField('Team Button Contribution', Box(info.team_btn_str))
+            EmbedField('Card Button Damage', BlockText(info.card_btn_str)),
+            EmbedField('Team Button Contribution', BlockText(info.team_btn_str))
         ]
 
         return EmbedView(

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -1,0 +1,29 @@
+from discordmenu.embed.components import EmbedField, EmbedMain
+from discordmenu.embed.text import Text
+from discordmenu.embed.view import EmbedView
+from tsutils import embed_footer_with_state
+
+class ButtonInfoViewProps:
+    def __init__(self, result):
+        self.result = result
+
+
+class ButtonInfoView:
+    VIEW_TYPE = 'ButtonInfo'
+
+    @staticmethod
+    def embed(state, props: ButtonInfoViewProps):
+        info_str = props.result
+
+        fields = [
+            EmbedField('Info', Text(info_str))
+        ]
+
+        return EmbedView(
+            EmbedMain(
+                color=state.color,
+                title='Button Info'
+            ),
+            embed_footer=embed_footer_with_state(state),
+            embed_fields=fields
+        )

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -19,13 +19,6 @@ class ButtonInfoViewProps:
     def __init__(self, monster: "MonsterModel", info):
         self.monster = monster
         self.info = info
-        # TODO: probably won't use these
-        # self.main_damage = result.main_damage
-        # self.sub_damage = result.sub_damage
-        # self.total_damage = result.total_damage
-        # self.main_damage_with_atk_latent = result.main_damage_with_atk_latent
-        # self.sub_damage_with_atk_latent = result.sub_damage_with_atk_latent
-        # self.total_damage_with_atk_latent = result.total_damage_with_atk_latent
 
 
 def get_stats_without_latents(info):
@@ -55,6 +48,12 @@ class ButtonInfoView:
         fields = [
             EmbedField('Without Latents', get_stats_without_latents(info)),
             EmbedField('With Latents', get_stats_with_latents(info)),
+            EmbedField(
+                'Damage From Common Buttons',
+                Text('Inherits are assumed to be the max possible level (up to 110) and +297')
+            ),
+            EmbedField('Card Buttons', Box(info.card_btn_str)),
+            EmbedField('Team Buttons', Box(info.team_btn_str))
         ]
 
         return EmbedView(


### PR DESCRIPTION
Resolves #1072. Resolves #1248.

* Makes `[p]buttoninfo` into an embed.
* Adjusts some formatting of damage display.
* Indicates if an equip is oncolor or not.
* Removes some old debugging print statements.