### PR TITLE
Add level 120 stats to buttoninfo

### DIFF
--- a/dadguide/models/monster_stats.py
+++ b/dadguide/models/monster_stats.py
@@ -5,14 +5,14 @@ StatType = Literal['hp', 'atk', 'rcv']
 
 
 class MonsterStatModifierInput:
-    def __init__(self, num_hp=0, num_atk=0, num_rcv=0, num_hppp=0, num_atkpp=0, num_rcvpp=0, num_all_stat=0,
+    def __init__(self, num_hp=0, num_atk=0, num_rcv=0, num_hpplus=0, num_atkplus=0, num_rcvplus=0, num_all_stat=0,
                  num_hp_awakening=0, num_atk_awakening=0, num_rcv_awakening=0, num_voice_awakening=0):
         self.num_hp = num_hp
         self.num_atk = num_atk
         self.num_rcv = num_rcv
-        self.num_hppp = num_hppp
-        self.num_atkpp = num_atkpp
-        self.num_rcvpp = num_rcvpp
+        self.num_hpplus = num_hpplus
+        self.num_atkplus = num_atkplus
+        self.num_rcvplus = num_rcvplus
         self.num_all_stat = num_all_stat
         self.num_hp_awakening = num_hp_awakening
         self.num_atk_awakening = num_atk_awakening
@@ -21,11 +21,11 @@ class MonsterStatModifierInput:
 
     def get_latent_multiplier(self, key: StatType):
         if key == 'hp':
-            return self.num_hp * 0.015 + self.num_hppp * 0.045 + self.num_all_stat * 0.03
+            return self.num_hp * 0.015 + self.num_hpplus * 0.045 + self.num_all_stat * 0.03
         elif key == 'atk':
-            return self.num_atk * 0.01 + self.num_atkpp * 0.03 + self.num_all_stat * 0.02
+            return self.num_atk * 0.01 + self.num_atkplus * 0.03 + self.num_all_stat * 0.02
         elif key == 'rcv':
-            return self.num_rcv * 0.1 + self.num_rcvpp * 0.3 + self.num_all_stat * 0.2
+            return self.num_rcv * 0.1 + self.num_rcvplus * 0.3 + self.num_all_stat * 0.2
         return 0
 
     def get_awakening_addition(self, key: StatType):

--- a/dadguide/models/monster_stats.py
+++ b/dadguide/models/monster_stats.py
@@ -5,14 +5,18 @@ StatType = Literal['hp', 'atk', 'rcv']
 
 
 class MonsterStatModifierInput:
-    def __init__(self, num_hp=0, num_atk=0, num_rcv=0, num_hpplus=0, num_atkplus=0, num_rcvplus=0, num_all_stat=0,
-                 num_hp_awakening=0, num_atk_awakening=0, num_rcv_awakening=0, num_voice_awakening=0):
+    def __init__(self, num_hp=0, num_atk=0, num_rcv=0, num_hpplus=0, num_atkplus=0, num_rcvplus=0, num_hpplus2=0,
+                 num_atkplus2=0, num_rcvplus2=0, num_all_stat=0, num_hp_awakening=0, num_atk_awakening=0,
+                 num_rcv_awakening=0, num_voice_awakening=0):
         self.num_hp = num_hp
         self.num_atk = num_atk
         self.num_rcv = num_rcv
         self.num_hpplus = num_hpplus
         self.num_atkplus = num_atkplus
         self.num_rcvplus = num_rcvplus
+        self.num_hpplus2 = num_hpplus2
+        self.num_atkplus2 = num_atkplus2
+        self.num_rcvplus2 = num_rcvplus2
         self.num_all_stat = num_all_stat
         self.num_hp_awakening = num_hp_awakening
         self.num_atk_awakening = num_atk_awakening
@@ -21,11 +25,11 @@ class MonsterStatModifierInput:
 
     def get_latent_multiplier(self, key: StatType):
         if key == 'hp':
-            return self.num_hp * 0.015 + self.num_hpplus * 0.045 + self.num_all_stat * 0.03
+            return self.num_hp * 0.015 + self.num_hpplus * 0.045 + self.num_hpplus2 * 0.1 + self.num_all_stat * 0.03
         elif key == 'atk':
-            return self.num_atk * 0.01 + self.num_atkplus * 0.03 + self.num_all_stat * 0.02
+            return self.num_atk * 0.01 + self.num_atkplus * 0.03 + self.num_atkplus2 * 0.05 + self.num_all_stat * 0.02
         elif key == 'rcv':
-            return self.num_rcv * 0.1 + self.num_rcvplus * 0.3 + self.num_all_stat * 0.2
+            return self.num_rcv * 0.1 + self.num_rcvplus * 0.3 + self.num_rcvplus2 * 0.35 + self.num_all_stat * 0.2
         return 0
 
     def get_awakening_addition(self, key: StatType):

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -72,9 +72,17 @@ class ButtonInfo:
         sub_attr_multiplier = self._get_sub_attr_multiplier(monster_model)
 
         result = ButtonInfoResult()
-        result.main_damage = self._calculate_damage(dgcog, monster_model, max_level, 0)
+        result.main_damage = self._calculate_damage(dgcog, monster_model, max_level)
         result.sub_damage = result.main_damage * sub_attr_multiplier
         result.total_damage = result.main_damage + result.sub_damage
+        if slb_level is None:
+            result.main_slb_damage = None
+            result.sub_slb_damage = None
+            result.total_slb_damage = None
+        else:
+            result.main_slb_damage = self._calculate_damage(dgcog, monster_model, slb_level)
+            result.sub_slb_damage = result.main_slb_damage * sub_attr_multiplier
+            result.total_slb_damage = result.main_slb_damage + result.sub_slb_damage
 
         result.main_damage_with_atk_latent = self._calculate_damage(
             dgcog, monster_model, max_level, num_atkplus_latent=max_atk_latents)
@@ -163,6 +171,9 @@ class ButtonInfoResult:
     main_damage: float
     total_damage: float
     sub_damage: float
+    main_slb_damage: float
+    total_slb_damage: float
+    sub_slb_damage: float
     main_damage_with_atk_latent: float
     total_damage_with_atk_latent: float
     sub_damage_with_atk_latent: float

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -82,8 +82,8 @@ class ButtonInfo:
         result.team_btn_str = self._get_team_btn_damage(TEAM_BUTTONS, dgcog, monster_model)
         return result
 
-    def _calculate_damage(self, dgcog, monster_model, level, num_atkpp_latent=0):
-        stat_latents = dgcog.MonsterStatModifierInput(num_atkpp=num_atkpp_latent)
+    def _calculate_damage(self, dgcog, monster_model, level, num_atkplus_latent=0):
+        stat_latents = dgcog.MonsterStatModifierInput(num_atkplus=num_atkplus_latent)
         stat_latents.num_atk_awakening = len(
             [x for x in monster_model.awakenings if x.awoken_skill_id == 1])
 
@@ -115,7 +115,7 @@ class ButtonInfo:
             inherit_model = dgcog.get_monster(card.id, server=monster.server_priority)
             max_level = LIMIT_BREAK_LEVEL if monster.limit_mult != 0 else monster.level
             inherit_max_level = LIMIT_BREAK_LEVEL if inherit_model.limit_mult != 0 else inherit_model.level
-            stat_latents = dgcog.MonsterStatModifierInput(num_atkpp=monster.latent_slots / 2)
+            stat_latents = dgcog.MonsterStatModifierInput(num_atkplus=monster.latent_slots / 2)
             dmg = int(round(dgcog.monster_stats.stat(monster, 'atk', max_level, stat_latents=stat_latents,
                       inherited_monster=inherit_model, multiplayer=True, inherited_monster_lvl=inherit_max_level)))
             oncolor = '*' if monster.attr1.value == inherit_model.attr1.value or monster.attr1.name == NIL_ATT else ' '
@@ -131,7 +131,7 @@ class ButtonInfo:
             inherit_model = dgcog.get_monster(card.id, server=monster.server_priority)
             max_level = LIMIT_BREAK_LEVEL if monster.limit_mult != 0 else monster.level
             inherit_max_level = LIMIT_BREAK_LEVEL if inherit_model.limit_mult != 0 else inherit_model.level
-            stat_latents = dgcog.MonsterStatModifierInput(num_atkpp=monster.latent_slots / 2)
+            stat_latents = dgcog.MonsterStatModifierInput(num_atkplus=monster.latent_slots / 2)
             dmg = dgcog.monster_stats.stat(monster, 'atk', max_level, stat_latents=stat_latents,
                                            inherited_monster=inherit_model, multiplayer=True, inherited_monster_lvl=inherit_max_level)
             if(monster.attr1.value in card.att):

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+import prettytable
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedAuthor, EmbedField, EmbedMain
 from discordmenu.embed.text import Text, BlockText
@@ -32,13 +33,34 @@ def get_stats_without_latents(info):
 
 
 def get_stats_with_latents(info):
-    return BlockText(
-        Box(
+    if info.main_damage_with_slb_atk_latent is None:
+        table = Box(
             Text('Base:    {}'.format(int(round(info.main_damage_with_atk_latent)))),
             Text('Subattr: {}'.format(int(round(info.sub_damage_with_atk_latent)))),
             Text('Total:   {}'.format(int(round(info.total_damage_with_atk_latent))))
         )
-    )
+    else:
+        table = _slb_table(info)
+    return BlockText(table)
+
+
+def _slb_table(info):
+    main_110 = int(round(info.main_damage_with_atk_latent))
+    sub_110 = int(round(info.sub_damage_with_atk_latent))
+    total_110 = int(round(info.total_damage_with_atk_latent))
+    main_120 = int(round(info.main_damage_with_slb_atk_latent))
+    sub_120 = int(round(info.sub_damage_with_slb_atk_latent))
+    total_120 = int(round(info.total_damage_with_slb_atk_latent))
+
+    cols = ['', '110 (Atk+)', '120 (Atk++)']
+    tbl = prettytable.PrettyTable(cols)
+    tbl.hrules = prettytable.NONE
+    tbl.vrules = prettytable.NONE
+    tbl.align = "l"
+    tbl.add_row(['Base:', main_110, main_120])
+    tbl.add_row(['Subattr:', sub_110, sub_120])
+    tbl.add_row(['Total:', total_110, total_120])
+    return tbl.get_string()
 
 
 class ButtonInfoView:

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -7,7 +7,7 @@ from discordmenu.embed.view import EmbedView
 from tsutils import embed_footer_with_state
 
 from padinfo.common.external_links import puzzledragonx
-from padinfo.core.button_info import button_info
+from padinfo.core.button_info import button_info, LIMIT_BREAK_LEVEL
 from padinfo.view.components.monster.header import MonsterHeader
 from padinfo.view.components.monster.image import MonsterImage
 
@@ -19,6 +19,11 @@ class ButtonInfoViewProps:
     def __init__(self, monster: "MonsterModel", info):
         self.monster = monster
         self.info = info
+
+
+def get_max_level(monster):
+    level_text = str(LIMIT_BREAK_LEVEL) if monster.limit_mult != 0 else 'Max ({})'.format(monster.level)
+    return 'Lv. {}'.format(level_text)
 
 
 def get_max_stats_without_latents(info):
@@ -71,7 +76,7 @@ class ButtonInfoView:
 
         fields = [
             EmbedField(
-                'Lv. Max',
+                get_max_level(monster),
                 Box(
                     Text('Without Latents'),
                     # avoid whitespace after code block
@@ -99,7 +104,7 @@ class ButtonInfoView:
                 inline=True
             ) if info.main_damage_with_slb_atk_latent is not None else None,
             EmbedField(
-                'Common Buttons',
+                'Common Buttons - {}'.format(get_max_level(monster)),
                 Box(
                     Text('*Inherits are assumed to be the max possible level (up to 110) and +297.*'),
                     # janky, but python gives DeprecationWarnings when using \* in a regular string

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -22,30 +22,6 @@ class ButtonInfoViewProps:
         self.info = info
 
 
-def get_stats_without_latents(info):
-    if info.main_damage_with_slb_atk_latent is None:
-        table = Box(
-            Text('Base:    {}'.format(int(round(info.main_damage)))),
-            Text('Subattr: {}'.format(int(round(info.sub_damage)))),
-            Text('Total:   {}'.format(int(round(info.total_damage))))
-        )
-    else:
-        table = _slb_table(info, latent=False)
-    return BlockText(table)
-
-
-def get_stats_with_latents(info):
-    if info.main_damage_with_slb_atk_latent is None:
-        table = Box(
-            Text('Base:    {}'.format(int(round(info.main_damage_with_atk_latent)))),
-            Text('Subattr: {}'.format(int(round(info.sub_damage_with_atk_latent)))),
-            Text('Total:   {}'.format(int(round(info.total_damage_with_atk_latent))))
-        )
-    else:
-        table = _slb_table(info, latent=True)
-    return BlockText(table)
-
-
 def _slb_table(info, latent: bool):
     if latent:
         cols = ['', 'Max (Atk+)', '120 (Atk++)']
@@ -74,6 +50,70 @@ def _slb_table(info, latent: bool):
     return tbl.get_string()
 
 
+def get_stats_without_latents(info):
+    if info.main_damage_with_slb_atk_latent is None:
+        table = Box(
+            Text('Base:    {}'.format(int(round(info.main_damage)))),
+            Text('Subattr: {}'.format(int(round(info.sub_damage)))),
+            Text('Total:   {}'.format(int(round(info.total_damage))))
+        )
+    else:
+        table = _slb_table(info, latent=False)
+    return BlockText(table)
+
+
+def get_stats_with_latents(info):
+    if info.main_damage_with_slb_atk_latent is None:
+        table = Box(
+            Text('Base:    {}'.format(int(round(info.main_damage_with_atk_latent)))),
+            Text('Subattr: {}'.format(int(round(info.sub_damage_with_atk_latent)))),
+            Text('Total:   {}'.format(int(round(info.total_damage_with_atk_latent))))
+        )
+    else:
+        table = _slb_table(info, latent=True)
+    return BlockText(table)
+
+
+def get_max_stats_without_latents(info):
+    return BlockText(
+        Box(
+            Text('Base:    {}'.format(int(round(info.main_damage)))),
+            Text('Subattr: {}'.format(int(round(info.sub_damage)))),
+            Text('Total:   {}'.format(int(round(info.total_damage))))
+        )
+    )
+
+
+def get_120_stats_without_latents(info):
+    return BlockText(
+        Box(
+            Text('Base:    {}'.format(int(round(info.main_slb_damage)))),
+            Text('Subattr: {}'.format(int(round(info.sub_slb_damage)))),
+            Text('Total:   {}'.format(int(round(info.total_slb_damage))))
+        )
+    )
+
+
+def get_max_stats_with_latents(info):
+    return BlockText(
+        Box(
+            Text('Base:    {}'.format(int(round(info.main_damage_with_atk_latent)))),
+            Text('Subattr: {}'.format(int(round(info.sub_damage_with_atk_latent)))),
+            Text('Total:   {}'.format(int(round(info.total_damage_with_atk_latent))))
+        )
+    )
+
+
+def get_120_stats_with_latents(info):
+    return BlockText(
+        Box(
+            Text('Base:    {}'.format(int(round(info.main_damage_with_slb_atk_latent)))),
+            Text('Subattr: {}'.format(int(round(info.sub_damage_with_slb_atk_latent)))),
+            Text('Total:   {}'.format(int(round(info.total_damage_with_slb_atk_latent))))
+        )
+    )
+
+
 class ButtonInfoView:
     VIEW_TYPE = 'ButtonInfo'
 
@@ -83,8 +123,34 @@ class ButtonInfoView:
         info = props.info
 
         fields = [
-            EmbedField('Without Latents', get_stats_without_latents(info)),
-            EmbedField('With Latents', get_stats_with_latents(info)),
+            # EmbedField('Without Latents', get_stats_without_latents(info)),
+            # EmbedField('With Latents', get_stats_with_latents(info)),
+            EmbedField(
+                'Lv. Max',
+                Box(
+                    Text('Without Latents'),
+                    Box(
+                        get_max_stats_without_latents(info),
+                        Text('With Latents (Atk+)'),
+                        delimiter=''
+                    ),
+                    get_max_stats_with_latents(info)
+                ),
+                inline=True
+            ),
+            EmbedField(
+                'Lv. 120',
+                Box(
+                    Text('Without Latents'),
+                    Box(
+                        get_120_stats_without_latents(info),
+                        Text('With Latents (Atk++)'),
+                        delimiter=''
+                    ),
+                    get_120_stats_with_latents(info)
+                ),
+                inline=True
+            ) if info.main_damage_with_slb_atk_latent is not None else None,
             EmbedField(
                 'Common Buttons',
                 Box(

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -102,7 +102,7 @@ class ButtonInfoView:
                     get_120_stats_with_latents(info)
                 ),
                 inline=True
-            ) if info.main_damage_with_slb_atk_latent is not None else None,
+            ) if monster.limit_mult != 0 else None,
             EmbedField(
                 'Common Buttons - {}'.format(get_max_level(monster)),
                 Box(

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -23,13 +23,15 @@ class ButtonInfoViewProps:
 
 
 def get_stats_without_latents(info):
-    return BlockText(
-        Box(
+    if info.main_damage_with_slb_atk_latent is None:
+        table = Box(
             Text('Base:    {}'.format(int(round(info.main_damage)))),
             Text('Subattr: {}'.format(int(round(info.sub_damage)))),
             Text('Total:   {}'.format(int(round(info.total_damage))))
         )
-    )
+    else:
+        table = _slb_table(info, latent=False)
+    return BlockText(table)
 
 
 def get_stats_with_latents(info):
@@ -40,19 +42,28 @@ def get_stats_with_latents(info):
             Text('Total:   {}'.format(int(round(info.total_damage_with_atk_latent))))
         )
     else:
-        table = _slb_table(info)
+        table = _slb_table(info, latent=True)
     return BlockText(table)
 
 
-def _slb_table(info):
-    main_110 = int(round(info.main_damage_with_atk_latent))
-    sub_110 = int(round(info.sub_damage_with_atk_latent))
-    total_110 = int(round(info.total_damage_with_atk_latent))
-    main_120 = int(round(info.main_damage_with_slb_atk_latent))
-    sub_120 = int(round(info.sub_damage_with_slb_atk_latent))
-    total_120 = int(round(info.total_damage_with_slb_atk_latent))
+def _slb_table(info, latent: bool):
+    if latent:
+        cols = ['', 'Max (Atk+)', '120 (Atk++)']
+        main_110 = int(round(info.main_damage_with_atk_latent))
+        sub_110 = int(round(info.sub_damage_with_atk_latent))
+        total_110 = int(round(info.total_damage_with_atk_latent))
+        main_120 = int(round(info.main_damage_with_slb_atk_latent))
+        sub_120 = int(round(info.sub_damage_with_slb_atk_latent))
+        total_120 = int(round(info.total_damage_with_slb_atk_latent))
+    else:
+        cols = ['', 'Max Level', '120']
+        main_110 = int(round(info.main_damage))
+        sub_110 = int(round(info.sub_damage))
+        total_110 = int(round(info.total_damage))
+        main_120 = int(round(info.main_slb_damage))
+        sub_120 = int(round(info.sub_slb_damage))
+        total_120 = int(round(info.total_slb_damage))
 
-    cols = ['', '110 (Atk+)', '120 (Atk++)']
     tbl = prettytable.PrettyTable(cols)
     tbl.hrules = prettytable.NONE
     tbl.vrules = prettytable.NONE

--- a/padinfo/view/button_info.py
+++ b/padinfo/view/button_info.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-import prettytable
 from discordmenu.embed.base import Box
 from discordmenu.embed.components import EmbedAuthor, EmbedField, EmbedMain
 from discordmenu.embed.text import Text, BlockText
@@ -20,58 +19,6 @@ class ButtonInfoViewProps:
     def __init__(self, monster: "MonsterModel", info):
         self.monster = monster
         self.info = info
-
-
-def _slb_table(info, latent: bool):
-    if latent:
-        cols = ['', 'Max (Atk+)', '120 (Atk++)']
-        main_110 = int(round(info.main_damage_with_atk_latent))
-        sub_110 = int(round(info.sub_damage_with_atk_latent))
-        total_110 = int(round(info.total_damage_with_atk_latent))
-        main_120 = int(round(info.main_damage_with_slb_atk_latent))
-        sub_120 = int(round(info.sub_damage_with_slb_atk_latent))
-        total_120 = int(round(info.total_damage_with_slb_atk_latent))
-    else:
-        cols = ['', 'Max Level', '120']
-        main_110 = int(round(info.main_damage))
-        sub_110 = int(round(info.sub_damage))
-        total_110 = int(round(info.total_damage))
-        main_120 = int(round(info.main_slb_damage))
-        sub_120 = int(round(info.sub_slb_damage))
-        total_120 = int(round(info.total_slb_damage))
-
-    tbl = prettytable.PrettyTable(cols)
-    tbl.hrules = prettytable.NONE
-    tbl.vrules = prettytable.NONE
-    tbl.align = "l"
-    tbl.add_row(['Base:', main_110, main_120])
-    tbl.add_row(['Subattr:', sub_110, sub_120])
-    tbl.add_row(['Total:', total_110, total_120])
-    return tbl.get_string()
-
-
-def get_stats_without_latents(info):
-    if info.main_damage_with_slb_atk_latent is None:
-        table = Box(
-            Text('Base:    {}'.format(int(round(info.main_damage)))),
-            Text('Subattr: {}'.format(int(round(info.sub_damage)))),
-            Text('Total:   {}'.format(int(round(info.total_damage))))
-        )
-    else:
-        table = _slb_table(info, latent=False)
-    return BlockText(table)
-
-
-def get_stats_with_latents(info):
-    if info.main_damage_with_slb_atk_latent is None:
-        table = Box(
-            Text('Base:    {}'.format(int(round(info.main_damage_with_atk_latent)))),
-            Text('Subattr: {}'.format(int(round(info.sub_damage_with_atk_latent)))),
-            Text('Total:   {}'.format(int(round(info.total_damage_with_atk_latent))))
-        )
-    else:
-        table = _slb_table(info, latent=True)
-    return BlockText(table)
 
 
 def get_max_stats_without_latents(info):
@@ -123,12 +70,11 @@ class ButtonInfoView:
         info = props.info
 
         fields = [
-            # EmbedField('Without Latents', get_stats_without_latents(info)),
-            # EmbedField('With Latents', get_stats_with_latents(info)),
             EmbedField(
                 'Lv. Max',
                 Box(
                     Text('Without Latents'),
+                    # avoid whitespace after code block
                     Box(
                         get_max_stats_without_latents(info),
                         Text('With Latents (Atk+)'),
@@ -142,6 +88,7 @@ class ButtonInfoView:
                 'Lv. 120',
                 Box(
                     Text('Without Latents'),
+                    # avoid whitespace after code block
                     Box(
                         get_120_stats_without_latents(info),
                         Text('With Latents (Atk++)'),


### PR DESCRIPTION
Resolves #1073.

* Adds calculations for level 120 stats and stat++ latents.
* Separates stat display into two columns for level up to 110 and for level 120. The level 120 column is hidden if the monster cannot limit break.