### PR TITLE
Make enhancements to buttoninfo

### DIFF
--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -34,6 +34,7 @@ TEAM_BUTTONS = [
     MonsterStat("Ryuno Ume{}   ", 5252, 80, [2, 4])
 ]
 CARD_BUTTONS = [
+    MonsterStat("Assassin{}     ", 5021, 200, []),
     MonsterStat("Satan{}        ", 4286, 300, []),
     MonsterStat("Durandalf Eq{} ", 4723, 300, []),
     MonsterStat("Brachydios Eq{}", 4152, 350, []),

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -22,8 +22,8 @@ Inherits are assumed to be the max possible level (up to 110) and +297
 {}
 """
 
-TEAM_BUTTON_FORMAT = "[{}] {} ({}x {}): {}"
-CARD_BUTTON_FORMAT = "[{}] {} ({}x): {}"
+TEAM_BUTTON_FORMAT = "[{}] {} ({} {}): {}"
+CARD_BUTTON_FORMAT = "[{}] {} ({}): {}"
 
 MonsterStat = namedtuple('MonsterStat', 'name id mult att')
 


### PR DESCRIPTION
Resolves #1265. Resolves #1266.

* Adds [5021] servant, assassin to buttoninfo card buttons.
* Removes Xs from button text. e.g. `(450): 3805200`, `(40 GD): 253666.67`