### PR TITLE
Properly escape emoji in channelmirror

### DIFF
--- a/channelmirror/channelmirror.py
+++ b/channelmirror/channelmirror.py
@@ -487,7 +487,7 @@ class ChannelMirror(commands.Cog):
         text = re.sub(r"@everyone\b", "@\u200beveryone", text)
         text = re.sub(r"@here\b", "@\u200bhere", text)
         # EMOJI
-        # text = self.emojify(text)
+        text = self.emojify(text)
         return text
 
     def emojify(self, message):


### PR DESCRIPTION
Closes #1325