### PR TITLE
Fix bugs with buttoninfo and stat calculation

### DIFF
--- a/dbcog/models/monster_stats.py
+++ b/dbcog/models/monster_stats.py
@@ -72,13 +72,14 @@ class MonsterStats:
                 # inherit=True to calculate inherit stats and multiplayer=False in case the inherit has a multiboost awakening
                 s_val += round(self.stat(inherited_monster, key, inherited_monster_lvl,
                                    inherit=True, multiplayer=False))
-            # add bonus atk, hp, or rcv awakenings
-            inherit_bonus = MonsterStatModifierInput(
-                num_hp_awakening=inherited_monster.awakening_count(AwokenSkills.ENHANCEDHP.value),
-                num_atk_awakening=inherited_monster.awakening_count(AwokenSkills.ENHANCEDATK.value),
-                num_rcv_awakening=inherited_monster.awakening_count(AwokenSkills.ENHANCEDRCV.value)
-            )
-            s_val += inherit_bonus.get_awakening_addition(key)
+            # add bonus atk, hp, or rcv awakenings iff the inherit has awoken assist
+            if inherited_monster.is_equip:
+                inherit_bonus = MonsterStatModifierInput(
+                    num_hp_awakening=inherited_monster.awakening_count(AwokenSkills.ENHANCEDHP.value),
+                    num_atk_awakening=inherited_monster.awakening_count(AwokenSkills.ENHANCEDATK.value),
+                    num_rcv_awakening=inherited_monster.awakening_count(AwokenSkills.ENHANCEDRCV.value)
+                )
+                s_val += inherit_bonus.get_awakening_addition(key)
 
         if multiplayer:
             num_multiboost = monster_model.awakening_count(AwokenSkills.MULTIBOOST.value)

--- a/dbcog/models/monster_stats.py
+++ b/dbcog/models/monster_stats.py
@@ -84,7 +84,7 @@ class MonsterStats:
         if multiplayer:
             num_multiboost = monster_model.awakening_count(AwokenSkills.MULTIBOOST.value)
             num_multiboost += inherited_monster.awakening_count(
-                AwokenSkills.MULTIBOOST.value) if inherited_monster.is_equip else 0
+                AwokenSkills.MULTIBOOST.value) if inherited_monster and inherited_monster.is_equip else 0
             s_val = round(round(s_val) * (1.5 ** num_multiboost))
 
         return s_val

--- a/dbcog/models/monster_stats.py
+++ b/dbcog/models/monster_stats.py
@@ -83,6 +83,8 @@ class MonsterStats:
 
         if multiplayer:
             num_multiboost = monster_model.awakening_count(AwokenSkills.MULTIBOOST.value)
+            num_multiboost += inherited_monster.awakening_count(
+                AwokenSkills.MULTIBOOST.value) if inherited_monster.is_equip else 0
             s_val = round(round(s_val) * (1.5 ** num_multiboost))
 
         return s_val

--- a/dbcog/models/monster_stats.py
+++ b/dbcog/models/monster_stats.py
@@ -82,8 +82,6 @@ class MonsterStats:
 
         if multiplayer:
             num_multiboost = monster_model.awakening_count(AwokenSkills.MULTIBOOST.value)
-            num_multiboost += inherited_monster.awakening_count(
-                AwokenSkills.MULTIBOOST.value) if inherited_monster else 0
             s_val = round(round(s_val) * (1.5 ** num_multiboost))
 
         return s_val

--- a/padinfo/core/button_info.py
+++ b/padinfo/core/button_info.py
@@ -223,9 +223,11 @@ class ButtonInfo:
             dmg = dbcog.monster_stats.stat(monster, 'atk', max_level, stat_latents=stat_latents,
                                            inherited_monster=inherit_model, multiplayer=multiplayer,
                                            inherited_monster_lvl=inherit_max_level)
-            if(monster.attr1.value in card.att):
+            # do count null main att monster damage as if it were the main att
+            if(monster.attr1.value in card.att or monster.attr1.name == NIL_ATT):
                 total_dmg += dmg
-            if(monster.attr2.value in card.att):
+            # do not double-count null main att
+            if(monster.attr2.value in card.att and monster.attr1.name != NIL_ATT):
                 total_dmg += dmg * self._get_sub_attr_multiplier(monster)
             colors_str = ""
             for i in card.att:


### PR DESCRIPTION
Resolves #1253.

* Calculates team button contribution for cards with nil main attribute.
* Fixes bug where an inherited card's stat and multiboost awakenings were being counted even when it did not have awoken assist.