### PR TITLE
Split/Grouped evos for results in ^ids

### DIFF
--- a/padinfo/view/monster_list/id_search.py
+++ b/padinfo/view/monster_list/id_search.py
@@ -1,5 +1,8 @@
 from typing import TYPE_CHECKING, List, Optional
 
+from tsutils.enums import EvoGrouping
+from tsutils.query_settings import QuerySettings
+
 from padinfo.view.monster_list.monster_list import MonsterListViewState
 
 if TYPE_CHECKING:
@@ -10,12 +13,16 @@ class IdSearchViewState(MonsterListViewState):
     VIEW_STATE_TYPE = "IdSearch"
 
     @classmethod
-    async def do_query(cls, dbcog, query, original_author_id) -> Optional[List["MonsterModel"]]:
+    async def do_query(cls, dbcog, query, original_author_id, query_settings: QuerySettings) \
+            -> Optional[List["MonsterModel"]]:
         found_monsters = await dbcog.find_monsters(query, original_author_id)
 
         if not found_monsters:
             return None
 
+        print(query_settings.serialize())
+        if query_settings.evogrouping == EvoGrouping.splitevos:
+            return found_monsters
         used = set()
         monster_list = []
         for mon in found_monsters:
@@ -28,5 +35,6 @@ class IdSearchViewState(MonsterListViewState):
 
     @classmethod
     async def query_from_ims(cls, dbcog, ims) -> List["MonsterModel"]:
-        monster_list = await cls.do_query(dbcog, ims['raw_query'], ims['original_author_id'])
+        monster_list = await cls.do_query(dbcog, ims['raw_query'], ims['original_author_id'],
+                                          QuerySettings.deserialize(ims['query_settings']))
         return monster_list


### PR DESCRIPTION
Closes #1369 

Please update to https://github.com/TsubakiBotPad/tsutils/pull/64 before merging

Also contains improvements to docstring messaging

Example query:

`^ids "planar" equip --splitevos`