### PR TITLE
Edit ^events to include Discord countdown

### DIFF
--- a/padevents/events.py
+++ b/padevents/events.py
@@ -93,12 +93,10 @@ class Event:
         return self.open_datetime.astimezone(tz)
 
     def start_from_now(self):
-        return f'{self.start_from_now_sec() // 3600:2}h' \
-               f' {(self.start_from_now_sec() % 3600) // 60:2}m'
+        return "<t:" + str(int(self.open_datetime.timestamp())) + ":R>"
 
     def end_from_now(self):
-        return f'{self.end_from_now_sec() // 3600:2}h' \
-               f' {(self.end_from_now_sec() % 3600) // 60:2}m'
+        return "<t:" + str(int(self.close_datetime.timestamp())) + ":R>"
 
     def end_from_now_full_min(self):
         days, sec = divmod(self.end_from_now_sec(), 86400)
@@ -128,10 +126,11 @@ class Event:
     def to_partial_event(self, pe):
         group = self.group_short_name()
         if self.is_started():
-            return group + " " + self.end_from_now() + "   " + self.name_and_modifier
+            return "`" + group + " " + self.name_and_modifier + " " * (
+                max(24 - len(self.name_and_modifier), 0)) + "-`" + self.end_from_now()
         else:
-            return group + " " + self.start_pst().strftime("%H:%M") + " " + self.start_est().strftime("%H:%M") \
-                   + " " + self.start_from_now() + " " + self.name_and_modifier
+            return "`" + group + " " + self.name_and_modifier + " " * (
+                max(24 - len(self.name_and_modifier), 0)) + "-`" + self.start_from_now()
 
 
 class EventList:

--- a/padevents/padevents.py
+++ b/padevents/padevents.py
@@ -426,20 +426,20 @@ class PadEvents(commands.Cog, AutoEvent):
             await ctx.send("No events available for " + server)
             return
 
-        output = "Events for {}".format(server)
+        output = "**Events for {}**".format(server)
 
         if len(active_events) > 0:
-            output += "\n\n" + "  Remaining Dungeon"
+            output += "\n\n" + "`  Remaining Dungeon       - Ending Time`"
             for e in active_events:
                 output += "\n" + e.to_partial_event(self)
 
         if len(pending_events) > 0:
-            output += "\n\n" + "  PT    ET    ETA     Dungeon"
+            output += "\n\n" + "`  Dungeon                 - ETA`"
             for e in pending_events:
                 output += "\n" + e.to_partial_event(self)
 
         for page in pagify(output):
-            await ctx.send(box(page))
+            await ctx.send(page)
 
     def get_most_recent_day_change(self):
         now = datetime.datetime.utcnow().time()


### PR DESCRIPTION
the length of 24 for the dungeon name is the max length that fits on my phone screen (though if a dungeon name is longer, it'll just overflow as needed. also when the countdown gets to minutes it overflows. it is coincidental that the max length of the current guerillas is 24 characters lol)
![image](https://user-images.githubusercontent.com/68720253/139161074-5185c086-c358-4e4f-b2a8-78e3c86aa838.png)
i only added the ETA countdown because you can hover to see the exact date in your tz... but i can add the exact time too? it'll overflow on phone regardless then

also does starter color even matter anymore???