### PR TITLE
Fix allmats for monsters with no mats

### DIFF
--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -640,7 +640,7 @@ class PadInfo(commands.Cog):
             await self.send_id_failure_message(ctx, query)
             return
         monster_list = await AllMatsViewState.do_query(dbcog, monster)
-        if monster_list is None:
+        if not monster_list:
             await ctx.send(inline("This monster is not a mat for anything nor does it have a gem"))
             return
 

--- a/padinfo/padinfo.py
+++ b/padinfo/padinfo.py
@@ -620,7 +620,7 @@ class PadInfo(commands.Cog):
         query_settings = QuerySettings.extract(await self.get_fm_flags(ctx.author), query)
         monster_list = await IdSearchViewState.do_query(dbcog, query, ctx.author.id, query_settings)
 
-        if monster_list is None:
+        if not monster_list:
             await ctx.send("No monster matched.")
             return
 


### PR DESCRIPTION
Changes how falsiness is checked for in a couple of places. `allmats` no longer errors if a monster with no mats is found.